### PR TITLE
Remove duplicate unreferenced "Dependabot alerts and updates" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,16 +498,6 @@ github:
 
 You can revert this by setting the variable back to false. (Merely removing the entry will not do that).
 
-<h3 id="dependabot">Dependabot alerts and updates</h3>
-
-Projects can enable and disable Dependabot alerts and automatic security update pull requests: 
-
-~~~yaml
-github:
-  dependabot_alerts:  true
-  dependabot_updates: false
-~~~
-
 <h3 id="depend_alerts">Dependabot alerts and updates</h3>
 
 Projects can enable and disable Dependabot alerts and automatic security update pull requests: 


### PR DESCRIPTION
The "Dependabot alerts and updates" section is duplicated in the readme, with only the second one referenced from the TOC:
https://github.com/apache/infrastructure-asfyaml/blob/6c955dae17029e915f6fe51cad1ef1c005ff1000/README.md#dependabot
https://github.com/apache/infrastructure-asfyaml/blob/6c955dae17029e915f6fe51cad1ef1c005ff1000/README.md#depend_alerts

This PR just deletes the first section to remove the duplication. Though perhaps something else was originally planned which lead to the situation?