### PR TITLE
Rework branch protection feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ It operates on a per-branch basis, meaning you can have different settings for d
     </ul>
   </li>
   <li><a href="#development">Further development</a></li>
+  <li><a href="#deployment">Deployment</a></li>
 </ul>
 
 <hr/>
@@ -781,5 +782,13 @@ These features have not been implemented in production yet, but are documented h
   None currently
 
 If you would like to add features please open a pull request or propose your changes via (github issue or infra ticket TBD.) The whole logic is defined in the `asfyaml.py` file that you create.
+
+<p align="right"><a href="#top">Return to top</a>
+
+<h2 id="deployment">Deployment</h2>
+
+The code that interprets your `.asf.yaml` and applies the configuration
+to the relevant systems is not public, but if you're an [Apache Committer](https://github.com/orgs/apache/teams/apache-committers)
+you can find it in [asfyaml.py](https://github.com/apache/infrastructure-p6/blob/production/modules/gitbox/files/asfgit/package/asfyaml.py)
 
 <p align="right"><a href="#top">Return to top</a>

--- a/asfyaml/feature/github/branch_protection.py
+++ b/asfyaml/feature/github/branch_protection.py
@@ -16,17 +16,17 @@
 # under the License.
 
 """GitHub branch protections"""
-from typing import Any, Union
+from typing import Any
 
 import github as pygithub
-from github.GithubObject import NotSet
+from github.GithubObject import NotSet, Opt
 import strictyaml
 import strictyaml.constants
 
 from . import directive, ASFGitHubFeature
 
 
-def to_bool(val: Any, key: str) -> Union[bool, NotSet]:
+def to_bool(val: Any, key: str) -> Opt[bool]:
     if val is None:
         return NotSet
     elif isinstance(val, bool):
@@ -40,7 +40,7 @@ def to_bool(val: Any, key: str) -> Union[bool, NotSet]:
             return False
 
 
-def to_int(val: Any, key: str) -> Union[int, NotSet]:
+def to_int(val: Any, key: str) -> Opt[int, NotSet]:
     if val is None:
         return NotSet
     elif isinstance(val, int):

--- a/asfyaml/feature/github/branch_protection.py
+++ b/asfyaml/feature/github/branch_protection.py
@@ -16,41 +16,12 @@
 # under the License.
 
 """GitHub branch protections"""
-from typing import Any
 
 import github as pygithub
-from github.GithubObject import NotSet, Opt
-import strictyaml
-import strictyaml.constants
+from github.GithubObject import NotSet
 
 from . import directive, ASFGitHubFeature
 
-
-def to_bool(val: Any, key: str) -> Opt[bool]:
-    if val is None:
-        return NotSet
-    elif isinstance(val, bool):
-        return val
-    elif str(val).lower() not in strictyaml.constants.BOOL_VALUES:
-        raise Exception(f"'{key}' requires a boolean value, encountered this instead '{val}'")
-    else:
-        if val.lower() in strictyaml.constants.TRUE_VALUES:
-            return True
-        else:
-            return False
-
-
-def to_int(val: Any, key: str) -> Opt[int, NotSet]:
-    if val is None:
-        return NotSet
-    elif isinstance(val, int):
-        return val
-
-    int_value = int(val)
-    if not isinstance(int_value, int):
-        raise Exception(f"'{key}' requires an integer value, encountered this instead '{val}'")
-
-    return int_value
 
 @directive
 def branch_protection(self: ASFGitHubFeature):
@@ -82,19 +53,18 @@ def branch_protection(self: ASFGitHubFeature):
         allow_force_push = False
 
         # Required signatures
-        required_signatures = to_bool(brsettings.get("required_signatures"), "required_signatures")
+        required_signatures = brsettings.get("required_signatures", NotSet), "required_signatures"
         if required_signatures is not NotSet:
             branch_changes.append(f"Set required signatures to {required_signatures}")
 
         # Required linear history
-        required_linear = to_bool(brsettings.get("required_linear_history"), "required_linear_history")
+        required_linear = brsettings.get("required_linear_history", NotSet)
         if required_linear is not NotSet:
             branch_changes.append(f"Set required linear history to {required_linear}")
 
         # Required conversation resolution
         # Requires all conversations to be resolved before merging is possible
-        required_conversation_resolution = to_bool(brsettings.get("required_conversation_resolution"),
-                                                   "required_conversation_resolution")
+        required_conversation_resolution = brsettings.get("required_conversation_resolution", NotSet),
         if required_conversation_resolution is not NotSet:
             branch_changes.append(f"Set required conversation resolution to {required_conversation_resolution}")
 
@@ -104,14 +74,11 @@ def branch_protection(self: ASFGitHubFeature):
         if "required_pull_request_reviews" in brsettings:
             required_pull_request_reviews = brsettings.get("required_pull_request_reviews", {})
 
-            required_approving_review_count = (
-                to_int(required_pull_request_reviews.get("required_approving_review_count", 0),
-                       "required_approving_review_count"))
+            required_approving_review_count = required_pull_request_reviews.get("required_approving_review_count", 0)
             if required_approving_review_count is not NotSet:
                 branch_changes.append(f"Set required approving review count to {required_approving_review_count}")
 
-            dismiss_stale_reviews = to_bool(required_pull_request_reviews.get("dismiss_stale_reviews"),
-                                            "dismiss_stale_reviews")
+            dismiss_stale_reviews = required_pull_request_reviews.get("dismiss_stale_reviews", NotSet)
             if dismiss_stale_reviews is not NotSet:
                 branch_changes.append(f"Set dismiss stale reviews to {dismiss_stale_reviews}")
         else:
@@ -124,7 +91,7 @@ def branch_protection(self: ASFGitHubFeature):
             required_status_checks = brsettings.get("required_status_checks", {})
 
             # strict means "Require branches to be up to date before merging".
-            require_strict = to_bool(required_status_checks.get("strict"), "strict")
+            require_strict = required_status_checks.get("strict", NotSet)
 
             contexts = required_status_checks.get("contexts", [])
             checks = required_status_checks.get("checks", [])


### PR DESCRIPTION
This PR reworks the way the branch protection feature works.

It looks at the specified settings in the `.asf.yaml` and retrieves them, otherwise they are considered to be NotSet, which means they will not be touched.

There are 2 exceptions:

 - `allow_force_pushes`: which is always set to false, which is the default behavior, but it will now also lead to the situation where existing branch protections rules will be modified if this setting is currently set to True on them
 - `required_approving_review_count` is set to 0 if `required_pull_request_reviews` is provided: that was also the behavior before and I did not want to change that

This PR also fixes the problem that we currently have on the ngparser that the logic wrt required_approving_review_count is broken and leads to a situation where `required_pull_request_reviews` is removed

Additionally, I added functionality to do as described in the README:

- for any branch not specified in the .asf.yml, the branch protections are removed if at least a `protected_branches` key is specified.

I did test this change on a fork of airflow, and the settings are correctly applied.

cc @potiuk