### PR TITLE
Improve logging of branch protection feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,41 @@ github:
       required_signatures: true
 ~~~
 
+The following settings are supported:
+
+```yanl
+required_signatures: <boolean>
+required_linear_history: <boolean>
+required_conversation_resolution: <boolean>
+required_pull_request_reviews:
+  dismiss_stale_reviews: <boolean>
+  require_code_owner_reviews: <boolean>
+  required_approving_review_count: <integer>
+required_status_checks:
+  strict: <boolean>
+  contexts:
+    - <string>
+  checks:
+    - context: <string>
+      app_id: <integer>
+```
+
+If not explicitly specified, these values will be used by default:
+
+```yaml
+required_signatures: false
+required_linear_history: false
+required_conversation_resolution: false
+required_pull_request_reviews:
+  dismiss_stale_reviews: false
+  require_code_owner_reviews: false
+  required_approving_review_count: 0
+required_status_checks:
+  strict: false
+  contexts: ~
+  checks: ~
+```
+
 **Notes**
   1. Enabling any of the above checks overrides what you may have set previously, so you'll need to add all the existing checks to your `.asf.yaml` file to reproduce any that Infra set manually for you.
   2. If you need to remove a required check in order to push a change to `.asf.yaml`, create an Infra Jira ticket with a request to have the check manually removed.
@@ -427,7 +462,7 @@ github:
     master: {}
 ~~~
 
-Branches that are not in your `.asf.yaml` file or are not dictionary entries are not protected.
+Branches that are not in your `.asf.yaml` file or are not dictionary entries are not protected and existing branch protections rules will be removed from them.
 
 To completely remove all branch protection rules, set the protected_branches section to null:
 

--- a/asfyaml/feature/github/branch_protection.py
+++ b/asfyaml/feature/github/branch_protection.py
@@ -54,37 +54,27 @@ def branch_protection(self: ASFGitHubFeature):
 
         # Required signatures
         required_signatures = brsettings.get("required_signatures", NotSet)
-        if required_signatures is not NotSet:
-            branch_changes.append(f"Set required signatures to {required_signatures}")
 
         # Required linear history
         required_linear = brsettings.get("required_linear_history", NotSet)
-        if required_linear is not NotSet:
-            branch_changes.append(f"Set required linear history to {required_linear}")
 
         # Required conversation resolution
         # Requires all conversations to be resolved before merging is possible
         required_conversation_resolution = brsettings.get("required_conversation_resolution", NotSet)
-        if required_conversation_resolution is not NotSet:
-            branch_changes.append(f"Set required conversation resolution to {required_conversation_resolution}")
 
         # Required pull requests reviews
         # As this is a nested object, we check for existence of the key to check if we should enable it
-        # If no further properties are provided, we use the default setting of required_approving_review_count = 0
         if "required_pull_request_reviews" in brsettings:
             required_pull_request_reviews = brsettings.get("required_pull_request_reviews", {})
 
             required_approving_review_count = required_pull_request_reviews.get("required_approving_review_count", 0)
-            if required_approving_review_count is not NotSet:
-                branch_changes.append(f"Set required approving review count to {required_approving_review_count}")
-
+            require_code_owner_reviews = required_pull_request_reviews.get("require_code_owner_reviews")
             dismiss_stale_reviews = required_pull_request_reviews.get("dismiss_stale_reviews", NotSet)
-            if dismiss_stale_reviews is not NotSet:
-                branch_changes.append(f"Set dismiss stale reviews to {dismiss_stale_reviews}")
         else:
             required_pull_request_reviews = NotSet
             required_approving_review_count = NotSet
             dismiss_stale_reviews = NotSet
+            require_code_owner_reviews = NotSet
 
         # Required status checks
         if "required_status_checks" in brsettings:
@@ -99,24 +89,78 @@ def branch_protection(self: ASFGitHubFeature):
 
             required_checks = list(checks_as_dict.items())
 
-            if len(required_checks) > 0:
-                branch_changes.append(f"Set required status contexts to the following:")
-                for ctx, appid in checks_as_dict.items():
-                    branch_changes.append(f"  - {ctx} (app_id: {appid})")
-
-                if require_strict is not NotSet:
-                    branch_changes.append(
-                        f"Set require branches to be up to date before merging (strict) to {require_strict}"
-                    )
-            else:
-                require_strict = NotSet
-                required_checks = NotSet
-                branch_changes.append(f"Remove required status checks")
-
+            # if no checks are defined, we remove the status checks completely
+            if len(required_checks) == 0:
+                required_status_checks = NotSet
         else:
             required_status_checks = NotSet
             require_strict = NotSet
             required_checks = NotSet
+
+        # Log changes that will be applied
+        try:
+            live_branch_protection_settings = ghbranch.get_protection()
+        except pygithub.GithubException:
+            live_branch_protection_settings = None
+
+        if (live_branch_protection_settings is None or
+                allow_force_push != live_branch_protection_settings.allow_force_pushes):
+            branch_changes.append(f"Set allow force push to {allow_force_push}")
+
+        if (required_signatures is not NotSet and
+                (live_branch_protection_settings is None or
+                 required_signatures != live_branch_protection_settings.required_signatures)):
+            branch_changes.append(f"Set required signatures to {required_signatures}")
+
+        if (required_linear is not NotSet and
+                (live_branch_protection_settings is None or
+                 required_linear != live_branch_protection_settings.required_linear_history)):
+            branch_changes.append(f"Set required linear history to {required_linear}")
+
+        if (required_conversation_resolution is not NotSet and
+                (live_branch_protection_settings is None or
+                 required_conversation_resolution != live_branch_protection_settings.required_conversation_resolution)):
+            branch_changes.append(f"Set required conversation resolution to {required_conversation_resolution}")
+
+        if required_pull_request_reviews is not NotSet:
+            if live_branch_protection_settings is None:
+                live_reviews = None
+            else:
+                live_reviews = live_branch_protection_settings.required_pull_request_reviews
+
+            if (required_approving_review_count is not NotSet and
+                    (live_reviews is None or
+                     required_approving_review_count != live_reviews.required_approving_review_count)):
+                branch_changes.append(f"Set required approving review count to {required_approving_review_count}")
+
+            if (require_code_owner_reviews is not NotSet and
+                    (live_reviews is None or
+                     require_code_owner_reviews != live_reviews.require_code_owner_reviews)):
+                branch_changes.append(f"Set required code owner reviews to {require_code_owner_reviews}")
+
+            if (dismiss_stale_reviews is not NotSet and
+                    (live_reviews is None or
+                     dismiss_stale_reviews != live_reviews.dismiss_stale_reviews)):
+                branch_changes.append(f"Set dismiss stale reviews to {dismiss_stale_reviews}")
+
+        if required_status_checks is not NotSet:
+            if live_branch_protection_settings is None:
+                live_status_checks = None
+            else:
+                live_status_checks = live_branch_protection_settings.required_status_checks
+
+            if (require_strict is not NotSet and
+                    (live_status_checks is None or require_strict != live_status_checks.strict)):
+                branch_changes.append(
+                    f"Set require branches to be up to date before merging (strict) to {require_strict}"
+                )
+
+            # Always log the required checks that will be set for now. We will need to parse
+            # the context field in a RequiredStatusChecks object.
+            if required_checks is not NotSet:
+                branch_changes.append(f"Set required status contexts to the following:")
+                for ctx, appid in required_checks:
+                    branch_changes.append(f"  - {ctx} (app_id: {appid})")
 
         # Apply all the changes
         if not self.noop("github::protected_branches"):
@@ -126,23 +170,26 @@ def branch_protection(self: ASFGitHubFeature):
                 required_conversation_resolution=required_conversation_resolution,
                 required_approving_review_count=required_approving_review_count,
                 dismiss_stale_reviews=dismiss_stale_reviews,
+                require_code_owner_reviews=require_code_owner_reviews,
                 strict=require_strict,
                 checks=required_checks,)
 
             if required_signatures is not NotSet:
-                if required_signatures:
+                if required_signatures and branch_protection_settings.required_signatures is False:
                     ghbranch.add_required_signatures()
-                else:
+                elif not required_signatures and branch_protection_settings.required_signatures is True:
                     ghbranch.remove_required_signatures()
 
             # if required pull requests are not enabled but present live, we need to explicitly remove them
             if (required_pull_request_reviews is NotSet and
                     branch_protection_settings.required_pull_request_reviews is not None):
+                branch_changes.append(f"Remove required pull request reviews")
                 ghbranch.remove_required_pull_request_reviews()
 
             # if required status checks are not enabled but present live, we need to explicitly remove them
             if (required_status_checks is NotSet and
                     branch_protection_settings.required_status_checks is not None):
+                branch_changes.append(f"Remove required status checks")
                 ghbranch.remove_required_status_checks()
 
         # Log all the changes we made to this branch


### PR DESCRIPTION
This PR adds the following changes:

- add documentation to the README about supported properties for protected_branches and their default values
- add support for required_code_owner_reviews as this was already in the schema
- improve logging of change to only output values that will be set / differ from the live settings