### PR TITLE
Speed up retrieval of protected branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,9 +474,6 @@ github:
   protected_branches: ~
 ~~~
 
-***Note***
-Removal of branch protection rules as described above is currently not supported due to performance degradations because of that.
-
 <h3 id="customsubject">Custom subject lines for GitHub events</h3>
 
 You can customize the subject lines for GitHub events (issues and pull requests being opened, closed, and commented on) on a per-repository basis.

--- a/asfyaml/feature/github/branch_protection.py
+++ b/asfyaml/feature/github/branch_protection.py
@@ -48,7 +48,7 @@ def run_paged_graphql_query(
         else:
             finished = True
 
-    return result
+    return total_result
 
 
 def get_protected_branches(self: ASFGitHubFeature) -> list[str]:


### PR DESCRIPTION
As the current method to retrieve the list of protected branches was too slow, we utilize a graphql query to retrieve all branch protection rules of a repo and map them to branches.

This makes the processing much faster and allows us to reenable that functionality.