### PR TITLE
Make collaborator feature more fail-safe

### DIFF
--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -144,6 +144,10 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
         self._ghrepo: pygithubrepo.Repository | None = None
 
     @property
+    def can_access_live_data(self) -> bool:
+        return self._ghrepo is not None
+
+    @property
     def ghrepo(self) -> pygithubrepo.Repository:
         if self._ghrepo is None:
             raise RuntimeError("something went wrong, ghrepo is not set")

--- a/asfyaml/feature/github/collaborators.py
+++ b/asfyaml/feature/github/collaborators.py
@@ -18,7 +18,7 @@
 """GitHub collaborator features"""
 
 import re
-import os
+
 from . import directive, ASFGitHubFeature, constants
 
 
@@ -27,32 +27,50 @@ def collaborators(self: ASFGitHubFeature):
     # Collaborator list for triage rights
     collabs = self.yaml.get("collaborators", [])
 
-    old_collabs = set()
     new_collabs = set(collabs)
+
     if collabs and self.repository.is_private:
         raise Exception("You cannot set outside collaborators for private repositories.")
+
     if len(new_collabs) > constants.MAX_COLLABORATORS:
         raise Exception(
-            f"You can only have a maximum of {constants.MAX_COLLABORATORS} external triage collaborators, please contact vp-infra@apache.org to request an exception."
+            f"You can only have a maximum of {constants.MAX_COLLABORATORS} external triage collaborators, "
+            f"please contact vp-infra@apache.org to request an exception."
         )
+
     for user in collabs:
         if not re.match(r"^[A-Za-z\d](?:[-A-Za-z\d]|-(?=[A-Za-z\d])){0,38}$", user):
             raise Exception("Username %s in collaborator list is not a valid GitHub ID!" % user)
-    collab_file = os.path.join(self.repository.path, "github_collaborators.txt")
-    if os.path.exists(collab_file):
-        old_collabs = set([x.strip() for x in open(collab_file) if x.strip()])
-    if new_collabs != old_collabs:
-        print("Updating collaborator list for GitHub")
-        to_remove = old_collabs - new_collabs
-        to_add = new_collabs - old_collabs
+
+    existing_collaborators = {c.login: c.permissions for c in self.ghrepo.get_collaborators()}
+    existing_collaborators_by_login = set(existing_collaborators)
+
+    to_remove = existing_collaborators_by_login - new_collabs
+    to_add = new_collabs - existing_collaborators_by_login
+
+    def has_elevated_permissions(user_login: str) -> bool:
+        permissions = existing_collaborators.get(user_login)
+        if permissions is None:
+            return False
+        return permissions.push or permissions.maintain or permissions.admin
+
+    # set of all existing collaborators with permissions other than triage
+    to_modify = {u for u in new_collabs if has_elevated_permissions(u)}
+
+    if len(to_add) > 0 or len(to_remove) > 0 or len(to_modify) > 0:
+        print("Updating collaborator list:")
+
         for user in to_remove:
-            print("Removing GitHub triage access for %s" % user)
+            print("  - Removing %s from list of collaborators" % user)
             if not self.noop("collaborators"):
                 self.ghrepo.remove_from_collaborators(user)
+
         for user in to_add:
-            print("Adding GitHub triage access for %s" % user)
+            print("  - Adding %s to list of collaborators with permission='triage'" % user)
             if not self.noop("collaborators"):
                 self.ghrepo.add_to_collaborators(user, permission="triage")
-        with open(collab_file, "w") as f:
-            f.write("\n".join(collabs))
-            f.close()
+
+        for user in to_modify:
+            print("  - Modifying collaborator permissions for %s to permission='triage'" % user)
+            if not self.noop("collaborators"):
+                self.ghrepo.add_to_collaborators(user, permission="triage")

--- a/asfyaml/feature/github/collaborators.py
+++ b/asfyaml/feature/github/collaborators.py
@@ -42,7 +42,11 @@ def collaborators(self: ASFGitHubFeature):
         if not re.match(r"^[A-Za-z\d](?:[-A-Za-z\d]|-(?=[A-Za-z\d])){0,38}$", user):
             raise Exception("Username %s in collaborator list is not a valid GitHub ID!" % user)
 
-    existing_collaborators = {c.login: c.permissions for c in self.ghrepo.get_collaborators()}
+    if self.can_access_live_data:
+        existing_collaborators = {c.login: c.permissions for c in self.ghrepo.get_collaborators()}
+    else:
+        existing_collaborators = {}
+
     existing_collaborators_by_login = set(existing_collaborators)
 
     to_remove = existing_collaborators_by_login - new_collabs


### PR DESCRIPTION
This PR changes the collaborators feature like that:

 - check the live settings instead of a cached file
 - check for elevated permissions and change to triage in such a case