### PR TITLE
Add note about GitHub Actions `app_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ github:
       ...
 ~~~
 
+> [!NOTE] The `app_id` of GitHub Actions is `15368`
 
 All protected branches in the YAML must be dictionary entries. Thus, if you only want to disable force push from a branch, you can construct a **minimal dictionary**:
 


### PR DESCRIPTION
Most repositories use at least the "GitHub Actions" GitHub App.

The `app_id` of "GitHub Actions" is `15368` and that value seems to work in `logging-log4j2`. Since from a user perspective, it's hard to find out the identifier of a GitHub App, it would be probably useful to list all the ids of applications installed at the `apache` organization level.