### PR TITLE
Add `app_slug` support to `required_status_checks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ required_status_checks:
   checks:
     - context: <string>
       app_id: <integer>
+      app_slug: <string>
 ```
 
 If not explicitly specified, these values will be used by default:
@@ -439,14 +440,18 @@ required_pull_request_reviews:
 required_status_checks:
   strict: false
   contexts: ~
-  checks: ~
+  checks:
 ```
 
 **Notes**
   1. Enabling any of the above checks overrides what you may have set previously, so you'll need to add all the existing checks to your `.asf.yaml` file to reproduce any that Infra set manually for you.
   2. If you need to remove a required check in order to push a change to `.asf.yaml`, create an Infra Jira ticket with a request to have the check manually removed.
 
-Using the 'contexts' list will automatically set an app ID of `-1` (any source) for checks. If you wish to specify a specific source app ID, you can make use of the expanded `checks` list instead:
+Using the 'contexts' list will automatically set an app ID of `-1` (any source) for checks. If you wish to specify a specific source app, you can make use of the expanded `checks` list instead and provide:
+
+- either an `app_slug` like `github-actions` or `github-advanced-security`. The correctness of the slug can be checked
+  accessing the URL `https://github.com/apps/<app_slug>`, e.g. https://github.com/apps/github-actions.
+- or an `app_id`
 
 ~~~yaml
 github:
@@ -456,10 +461,17 @@ github:
         # strict means "Require branches to be up to date before merging".
         strict: true
         checks:
+          # A Github Actions workflow name that must pass
+          - context: build / build (ubuntu-latest)
+            app_slug: github-actions
+          # A security check that must pass
+          - context: CodeQL
+            app_slug: github-advanced-security
+          # GitHub App specified by id
           - context: gh-infra/jenkins
             app_id: 1234
+          # Equivalent to any GitHub App
           - context: another/build-that-must-pass
-            app_id: -1
       ...
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ github:
         # contexts are the names of checks that must pass.
         contexts:
           - gh-infra/jenkins
-          - another/build-that-must-pass
+          - context: CodeQL
+            app: github-advanced-security
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: false
@@ -421,10 +422,8 @@ required_status_checks:
   strict: <boolean>
   contexts:
     - <string>
-  checks:
     - context: <string>
-      app_id: <integer>
-      app_slug: <string>
+      app: <integer> or <string>
 ```
 
 If not explicitly specified, these values will be used by default:
@@ -441,18 +440,17 @@ required_pull_request_reviews:
 required_status_checks:
   strict: false
   contexts: ~
-  checks:
 ```
 
 **Notes**
   1. Enabling any of the above checks overrides what you may have set previously, so you'll need to add all the existing checks to your `.asf.yaml` file to reproduce any that Infra set manually for you.
   2. If you need to remove a required check in order to push a change to `.asf.yaml`, create an Infra Jira ticket with a request to have the check manually removed.
 
-Using the 'contexts' list will automatically set an app ID of `-1` (any source) for checks. If you wish to specify a specific source app, you can make use of the expanded `checks` list instead and provide:
-
-- either an `app_slug` like `github-actions` or `github-advanced-security`. The correctness of the slug can be checked
-  accessing the URL `https://github.com/apps/<app_slug>`, e.g. https://github.com/apps/github-actions.
-- or an `app_id`
+The `contexts` list allows two kinds of entries:
+- If you wish to specify a specific source app, you need to provide a `context` property for the name of the check and an `app` property for the app.
+  You can use either the application's id or its slug.
+  The correctness of the slug can be checked accessing the URL `https://github.com/apps/<app_slug>`, e.g. https://github.com/apps/github-actions.
+- Otherwise, you can just specify the name of the check.
 
 ~~~yaml
 github:
@@ -464,15 +462,16 @@ github:
         checks:
           # A Github Actions workflow name that must pass
           - context: build / build (ubuntu-latest)
-            app_slug: github-actions
+            app: github-actions
           # A security check that must pass
           - context: CodeQL
-            app_slug: github-advanced-security
+            app: github-advanced-security
           # GitHub App specified by id
           - context: gh-infra/jenkins
-            app_id: 1234
+            app: 1234
           # Equivalent to any GitHub App
           - context: another/build-that-must-pass
+          - a-third/build-that-must-pass
       ...
 ~~~
 

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -160,7 +160,7 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
             raise RuntimeError("something went wrong, github is not set")
         try:
             return self._github.get_app(slug).id
-        except pygithub.GithubException as e:
+        except pygithub.GithubException:
             print(f"[github] Unable to find GitHub app for slug {slug}.")
             return None
 

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -117,16 +117,13 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
                         strictyaml.Optional("required_status_checks"): strictyaml.Map(
                             {
                                 strictyaml.Optional("strict", default=False): strictyaml.Bool(),
-                                strictyaml.Optional("contexts"): strictyaml.Seq(strictyaml.Str()),
-                                strictyaml.Optional("checks"): strictyaml.Seq(
-                                    strictyaml.Map(
+                                strictyaml.Optional("contexts"): strictyaml.Seq(
+                                    strictyaml.Str() | strictyaml.Map(
                                         {
                                             "context": strictyaml.Str(),
-                                            strictyaml.Optional("app_slug"): strictyaml.Str(),
-                                            strictyaml.Optional("app_id", default=-1): strictyaml.Int(),
+                                            strictyaml.Optional("app"): strictyaml.Int() | strictyaml.Str(),
                                         }
-                                    )
-                                ),
+                                    ))
                             }
                         ),
                     }
@@ -191,17 +188,6 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
         else:
             return self._ghrepo
 
-    def _get_app_id_slug(self, slug: str) -> int | None:
-        # Test run
-        if "noop" in self.instance.environments_enabled:
-            return 1234
-        if self._github is None:
-            raise RuntimeError("something went wrong, github is not set")
-        try:
-            return self._github.get_app(slug).id
-        except pygithub.GithubException:
-            print(f"[github] Unable to find GitHub app for slug {slug}.")
-            return None
 
     def run(self):
         """GitHub features"""

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -118,12 +118,14 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
                             {
                                 strictyaml.Optional("strict", default=False): strictyaml.Bool(),
                                 strictyaml.Optional("contexts"): strictyaml.Seq(
-                                    strictyaml.Str() | strictyaml.Map(
+                                    strictyaml.Str()
+                                    | strictyaml.Map(
                                         {
                                             "context": strictyaml.Str(),
                                             strictyaml.Optional("app"): strictyaml.Int() | strictyaml.Str(),
                                         }
-                                    ))
+                                    )
+                                ),
                             }
                         ),
                     }
@@ -187,7 +189,6 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
             raise RuntimeError("something went wrong, ghrepo is not set")
         else:
             return self._ghrepo
-
 
     def run(self):
         """GitHub features"""

--- a/asfyaml/feature/github/branch_protection.py
+++ b/asfyaml/feature/github/branch_protection.py
@@ -164,8 +164,10 @@ def branch_protection(self: ASFGitHubFeature):
 
             contexts = required_status_checks.get("contexts", [])
             checks = required_status_checks.get("checks", [])
-            checks_as_dict = {**{ctx: -1 for ctx in contexts},
-                              **{c["context"]: __get_app_id_check(self, c) for c in checks}}
+            checks_as_dict = {
+                **{ctx: -1 for ctx in contexts},
+                **{c["context"]: __get_app_id_check(self, c) for c in checks},
+            }
 
             required_checks = list(checks_as_dict.items())
 
@@ -179,7 +181,9 @@ def branch_protection(self: ASFGitHubFeature):
 
         # Log changes that will be applied
         try:
-            live_branch_protection_settings = self.ghrepo.get_branch(branch=branch).get_protection() if not dry_run else None
+            live_branch_protection_settings = (
+                self.ghrepo.get_branch(branch=branch).get_protection() if not dry_run else None
+            )
         except pygithub.GithubException:
             live_branch_protection_settings = None
 

--- a/asfyaml/feature/github/branch_protection.py
+++ b/asfyaml/feature/github/branch_protection.py
@@ -84,7 +84,7 @@ query($endCursor: String, $organization: String!, $repository: String!, $refPref
 
 
 def __context_get_name(context: str | dict) -> str:
-    return context if type(context) is str else context["context"]
+    return context if isinstance(context, str) else context["context"]
 
 
 def __slug_get_app_id(self: ASFGitHubFeature, slug: str) -> int | None:
@@ -100,10 +100,12 @@ def __slug_get_app_id(self: ASFGitHubFeature, slug: str) -> int | None:
 
 # Get the application id for a protected branch check
 def __context_get_app_id(self: ASFGitHubFeature, context: str | dict) -> int:
-    if type(context) is str:
+    if isinstance(context, str):
         return -1
     app = context.get("app")
-    return -1 if app is None else __slug_get_app_id(self, app) if type(app) is str else int(app)
+    if isinstance(app, str):
+        app = __slug_get_app_id(self, app)
+    return -1 if app is None else int(app)
 
 
 @directive

--- a/tests/github_branch_protection.py
+++ b/tests/github_branch_protection.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for .asf.yaml GitHub branch protection"""
+import strictyaml.exceptions
+
+from helpers import YamlTest
+import asfyaml.asfyaml
+import asfyaml.dataobjects
+
+# Set .asf.yaml to debug mode
+asfyaml.asfyaml.DEBUG = True
+
+
+valid_github_checks = YamlTest(
+    None,
+    None,
+    """
+github:
+  protected_branches:
+    main:
+      required_status_checks:
+        checks:
+            # Only slug
+          - context: "check1"
+            app_slug: github-actions
+            # Only id
+          - context: "check2"
+            app_id: 15368
+            # Only context
+          - context: "check3"
+""",
+)
+
+
+def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
+    print("[github] Testing branch protection")
+
+    tests_to_run = (
+        valid_github_checks,
+    )
+
+    for test in tests_to_run:
+        with test.ctx():
+            a = asfyaml.asfyaml.ASFYamlInstance(
+                repo=test_repo, committer="humbedooh", config_data=test.yaml, branch=asfyaml.dataobjects.DEFAULT_BRANCH
+            )
+            a.environments_enabled.add("noop")
+            a.no_cache = True
+            a.run_parts()

--- a/tests/github_branch_protection.py
+++ b/tests/github_branch_protection.py
@@ -16,8 +16,6 @@
 # under the License.
 
 """Unit tests for .asf.yaml GitHub branch protection"""
-import strictyaml.exceptions
-
 from helpers import YamlTest
 import asfyaml.asfyaml
 import asfyaml.dataobjects
@@ -34,15 +32,16 @@ github:
   protected_branches:
     main:
       required_status_checks:
-        checks:
+        contexts:
+          - "check1"
             # Only slug
-          - context: "check1"
-            app_slug: github-actions
-            # Only id
           - context: "check2"
-            app_id: 15368
-            # Only context
+            app: "github-actions"
+            # Only id
           - context: "check3"
+            app: 15368
+            # Only context
+          - context: "check4"
 """,
 )
 


### PR DESCRIPTION
This adds the possibility to use application slugs instead of application numerical ids to specify the required checks for a PR.

The slugs for third-party GitHub apps can be found on [GitHub Marketplace]. All slugs can be checked by accessing `https://github.com/apps/<app_slug>`.

Two common internal GitHub apps are `github-actions` and `github-advanced-security` and can be used as in the example below:

```yaml
github:
  protected_branches:
    main:
      required_status_checks:
        checks:
          # A Github Actions workflow name that must pass
          - context: build / build (ubuntu-latest)
            app_slug: github-actions
          # A security check that must pass
          - context: CodeQL
            app_slug: github-advanced-security
```

Closes #65