### PR TITLE
Add warning about required checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,9 @@ For more details on Branch Protection Rules in general, please refer to the [doc
 
 > [!WARNING]
 > The names of the required checks are not validated.
-> 
-> If you modify the `contexts` and `checks` setting for the default branch, consider testing it on a **non** default branch first.
+>
+> If you modify the `contexts` and `checks` setting for the default branch, consider testing it on a **non** default
+> branch first.
 > A typo in these settings for the default branch will prevent you from modifying the `.asf.yaml` file itself.
 
 Here are some examples:

--- a/README.md
+++ b/README.md
@@ -377,6 +377,12 @@ We will evaluate the need for other autolink features.
 Projects can enable branch protection in their repos, including most of the sub-level protection features such as 'require status checks to pass before merging' , 'approval by at least $n people' , and 'require pull request reviews'.
 For more details on Branch Protection Rules in general, please refer to the [documentation @ GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches).
 
+> [!WARNING]
+> The names of the required checks are not validated.
+> 
+> If you modify the `contexts` and `checks` setting for the default branch, consider testing it on a **non** default branch first.
+> A typo in these settings for the default branch will prevent you from modifying the `.asf.yaml` file itself.
+
 Here are some examples:
 
 ~~~yaml


### PR DESCRIPTION
Typos in the names and application ids of required checks for the default branch can brick the GitHub interface. Sure, the error can be corrected through GitBox, but for transparency reasons, it would be better never to resort to that.

This change adds a warning to test the required checks names on a **non** default branch first. If an error is introduced, it is always possible to modify the `.asf.yaml` file through GitHub.