### PR TITLE
Fix typo in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ jekyll:
 
 **Note**: In 2019 Infra created `ASF-Pelican` as a structure and template for projects to use to build their websites, and for the ASF's own website.
 
-In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https//:github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
+In 2024, Infra moved from ASF-Pelican to the ASF **Infrastructure Pelican Action** GitHub Action to perform the same functions without being closely tied to BuildBot. The repository for this GHA is <a href="https://github.com/apache/infrastructure-actions/tree/main/pelican" target="_blank">github.com/apache/infrastructure-actions/tree/main/pelican</a>.
 
 We are updating the help documentation for Pelican, which starts at <a href="https://infra.apache.org/asf-pelican.html" target="_blank">infra.apache.org/asf-pelican.html</a>, to provide what you need to know about the ASF Pelican GHA.
 


### PR DESCRIPTION
This seems to be the last copy and paste error, where the colon was placed on the wrong side of the slashes.