### PR TITLE
Support custom workflows with GH Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,10 +601,15 @@ This triggers emails when a workflow run fails or if it succeeds after a series 
 
 <h3 id="pages">GitHub Pages</h3>
 
-Projects that use GitHub for website publishing can enable/update GitHub Pages settings, by specifying which branch (and optional path) to publish:
+Projects that use GitHub for website publishing can enable/update GitHub Pages settings or delete existing GitHub Pages.
+
+<h4 id="ghp-legacy">Legacy Mode</h4>
+
+Legacy mode is used by default when no `ghp_type` parameter is specified. GitHub Pages can be enabled by specifying which branch (and optional path) to publish:
 
 ~~~yaml
 github:
+  ghp_type:    legacy  # optional
   ghp_branch:  master
   ghp_path:    /docs
 ~~~
@@ -614,6 +619,25 @@ The `ghp_branch` setting can **only** be your default branch (e.g. master, main,
 **Note**: This is subject to change as GitHub is relaxing the rules.
 
 The `ghp_path` setting should **always** be specified. It can be either `/docs` or `/`. If not specified, it will default to `/docs`.
+
+<h4 id="ghp-workflow">Workflow Mode</h4>
+
+In order to use [custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages) to publish to GitHub Pages,
+the `ghp_type` must be set to `workflow` and the other parameters removed (`ghp_branch`, `ghp_path`):
+
+~~~yaml
+github:
+  ghp_type: workflow
+~~~
+
+<h4 id="ghp-disabled">Disable GitHub Pages</h4>
+
+To explicitly disable GitHub Pages for a repository, set the `ghp_type` to `disabled`:
+
+~~~yaml
+github:
+  ghp_type: disabled
+~~~
 
 <h3 id="pull_requests">Pull Request settings</h3>
 

--- a/asfyaml/dataobjects.py
+++ b/asfyaml/dataobjects.py
@@ -225,6 +225,15 @@ class Repository:
         return hb
 
     @property
+    def default_branch_if_known(self) -> str | None:
+        """Returns the default branch for this repository."""
+        head_path = os.path.join(self.path, "HEAD")
+        if os.path.isfile(head_path):
+            return open(head_path).read().removeprefix("ref: refs/heads/").strip()
+        else:
+            return None
+
+    @property
     def changesets(self):
         """Yields a ChangeSet for each ref update seen in this push.
         Each ChangeSet can have several commits bundled"""

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -96,6 +96,7 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
                 strictyaml.Seq(JiraSpaceString()),
             ),
             # GitHub Pages: branch (can be default or gh-pages) and path (can be /docs or /)
+            strictyaml.Optional("ghp_type", default="legacy"): strictyaml.Str(),
             strictyaml.Optional("ghp_branch"): strictyaml.Str(),
             strictyaml.Optional("ghp_path", default="/docs"): strictyaml.Str(),
             # Branch protection rules - TODO: add actual schema

--- a/asfyaml/feature/github/pages.py
+++ b/asfyaml/feature/github/pages.py
@@ -17,77 +17,141 @@
 
 """GitHub pages feature"""
 
-from . import directive, ASFGitHubFeature, GH_TOKEN_FILE
+from typing import Any
+
+from . import directive, ASFGitHubFeature
 import requests
 
 
 @directive
 def config_pages(self: ASFGitHubFeature):
     # GitHub pages
+    ghp_type = self.yaml.get("ghp_type")
+
+    if ghp_type == "legacy":
+        _config_legacy(self)
+    elif ghp_type == "workflow":
+        _config_workflow(self)
+    elif ghp_type == "disabled":
+        _disable_gh_pages(self)
+    else:
+        raise Exception(f".asf.yaml: Invalid GitHub Pages type '{ghp_type}' - must be 'workflow' or 'legacy'!")
+
+
+def _config_workflow(self: ASFGitHubFeature):
+    ghp_branch = self.yaml.get("ghp_branch")
+    ghp_path = self.yaml.get("ghp_path")
+
+    if ghp_branch is not None:
+        raise Exception(
+            f".asf.yaml: Invalid GitHub Pages branch '{ghp_branch}' when ghp_type is 'workflow', remove parameter!"
+        )
+
+    if ghp_path is not None:
+        raise Exception(
+            f".asf.yaml: Invalid GitHub Pages path '{ghp_path}' when ghp_type is 'workflow', remove parameter!"
+        )
+
+    if self.noop("pages"):
+        print("Would have set GitHub Pages to type 'workflow'.")
+        return
+
+    data = {"build_type": "workflow"}
+    _config_ghp(self, data)
+
+
+def _disable_gh_pages(self: ASFGitHubFeature):
+    ghp_branch = self.yaml.get("ghp_branch")
+    ghp_path = self.yaml.get("ghp_path")
+
+    if ghp_branch is not None:
+        raise Exception(
+            f".asf.yaml: Invalid GitHub Pages branch '{ghp_branch}' when ghp_type is 'disabled', remove parameter!"
+        )
+
+    if ghp_path is not None:
+        raise Exception(
+            f".asf.yaml: Invalid GitHub Pages path '{ghp_path}' when ghp_type is 'disabled', remove parameter!"
+        )
+
+    if self.noop("pages"):
+        print("Would have deleted GitHub Pages.")
+        return
+
+    status_code, _, body = self.ghrepo._requester.requestJson(
+        "DELETE",
+        f"/repos/{self.repository.org_id}/{self.repository.name}/pages",
+    )
+
+    if status_code == 204 or status_code == 404:
+        print("Disabled GitHub Pages.")
+    else:
+        raise Exception(f"Failed to disable GitHub Pages: {status_code} -> {body}")
+
+
+def _config_legacy(self: ASFGitHubFeature):
     ghp_branch = self.yaml.get("ghp_branch")
     ghp_path = self.yaml.get("ghp_path", "/docs")
     if ghp_branch:
+        # determine the default branch of the repo, if the repo is not accessible locally, query the GH API
+        default_branch = self.repository.default_branch_if_known or self.ghrepo.default_branch
+
         if ghp_branch not in (
-            self.repository.default_branch,
+            default_branch,
             "gh-pages",
         ):
             raise Exception(
-                f".asf.yaml: Invalid GitHub Pages branch '{ghp_branch}' - must be default branch or gh-pages!"
+                f".asf.yaml: Invalid GitHub Pages branch '{ghp_branch}' - must be the default branch "
+                f"('{default_branch}') or 'gh-pages'!"
             )
 
         # Construct configuration for GitHub's API
         if ghp_path not in ["/docs", "/"]:
-            print(f"GitHub Pages path '{ghp_path}' is invalid, setting to /")
-            ghp_path = "/"
-        ghps = {"branch": ghp_branch, "path": ghp_path}
+            raise Exception(f".asf.yaml: Invalid GitHub Pages path '{ghp_path}' - must be either '/docs' or '/'!")
 
-        # The processing below only happens in non-test mode. Return otherwise.
         if self.noop("pages"):
-            print(f"Would have set GHP to branch '{ghp_branch}' and path '{ghp_path}'.")
+            print(f"Would have set GitHub Pages to branch '{ghp_branch}' and path '{ghp_path}'.")
             return
 
-        GHP_URL = f"https://api.github.com/repos/{self.repository.org_id}/{self.repository.name}/pages"
-        GHP_TOKEN = open(GH_TOKEN_FILE).read().strip()
+        data = {"build_type": "legacy", "source": {"branch": ghp_branch, "path": ghp_path}}
 
-        # Test if GHP is enabled already
-        rv = requests.get(
-            GHP_URL,
-            headers={
-                "Authorization": "token %s" % GHP_TOKEN,
-                "Accept": "application/vnd.github.switcheroo-preview+json",
-            },
-        )
+        _config_ghp(self, data)
 
-        # Not enabled yet, enable?!
-        if rv.status_code == 404:
-            try:
-                rv = requests.post(
-                    GHP_URL,
-                    headers={
-                        "Authorization": "token %s" % GHP_TOKEN,
-                        "Accept": "application/vnd.github.switcheroo-preview+json",
-                    },
-                    json={"source": ghps},
-                )
-                print("GitHub Pages set to branch=%s, path=%s" % (ghp_branch, ghp_path))
-            except requests.exceptions.RequestException:
-                print("Could not set GitHub Pages configuration!")
-        # Enabled, update settings?
-        elif 200 <= rv.status_code < 300:
-            try:
-                rv = requests.put(
-                    GHP_URL,
-                    headers={
-                        "Authorization": "token %s" % GHP_TOKEN,
-                        "Accept": "application/vnd.github.switcheroo-preview+json",
-                    },
-                    json={
-                        "source": ghps,
-                    },
-                )
-                print("GitHub Pages updated to %r" % ghps)
-                print(rv.status_code)
-                print(rv.text)
-            except requests.exceptions.RequestException:
-                print("Could not set GitHub Pages configuration!")
-    # TODO: Allow disabling GitHub Pages by removing the entries..
+
+def _config_ghp(self: ASFGitHubFeature, data: dict[str, Any]) -> None:
+    # Test if GHP is enabled already
+    status_code, headers, body = self.ghrepo._requester.requestJson(
+        "GET",
+        f"/repos/{self.repository.org_id}/{self.repository.name}/pages",
+    )
+
+    # Not enabled yet, enable?!
+    if status_code == 404:
+        try:
+            status_code, _, body = self.ghrepo._requester.requestJson(
+                "POST",
+                f"/repos/{self.repository.org_id}/{self.repository.name}/pages",
+                input=data,
+            )
+
+            if status_code == 201:
+                print("GitHub Pages set to %r" % data)
+            else:
+                raise Exception(f"Failed to create GitHub Pages: {status_code} -> {body}")
+        except requests.exceptions.RequestException:
+            print("Could not set GitHub Pages configuration!")
+    # Enabled, update settings?
+    elif 200 <= status_code < 300:
+        try:
+            status_code, _, body = self.ghrepo._requester.requestJson(
+                "PUT",
+                f"/repos/{self.repository.org_id}/{self.repository.name}/pages",
+                input=data,
+            )
+
+            if status_code == 204:
+                print("GitHub Pages updated to %r" % data)
+            else:
+                raise Exception(f"Failed to update GitHub Pages: {status_code} -> {body}")
+        except requests.exceptions.RequestException:
+            print("Could not set GitHub Pages configuration!")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,4 +34,8 @@ def test_repo(base_path: Path) -> asfyaml.dataobjects.Repository:
     os.environ["GIT_PROJECT_ROOT"] = str(base_path.joinpath("../repos/private"))
     if not os.path.isdir(repo_path):  # Make test repo dir
         os.makedirs(repo_path, exist_ok=True)
+
+    # create a fake HEAD file setting main as default branch
+    Path(os.path.join(repo_path, 'HEAD')).write_text("ref: refs/heads/main")
+
     return asfyaml.dataobjects.Repository(repo_path)

--- a/tests/github_pages.py
+++ b/tests/github_pages.py
@@ -58,6 +58,17 @@ github:
 """,
 )
 
+# branch cant be specified when ghp_type == workflow
+invalid_github_pages_workflow_bad_branch = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "Invalid GitHub Pages branch",
+    """
+github:
+    ghp_type: workflow
+    ghp_branch: foo
+""",
+)
+
 
 def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
     print("[github] Testing GitHub Pages features")
@@ -66,7 +77,7 @@ def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
         valid_github_pages,
         invalid_github_pages_garbage,
         invalid_github_pages_bad_branch,
-
+        invalid_github_pages_workflow_bad_branch
     )
 
     for test in tests_to_run:


### PR DESCRIPTION
This fixes #77 .

You can now either enable GH Pages with mode

- legacy (the default, deploy from a branch / path)
- workflow: setting `ghp_type` to `workflow`

or disable GH Pages altogether by setting `ghp_type` to `disabled`.