### PR TITLE
docs: add deprecation notice for GitHub tag protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,10 @@ To remove labels from the repository, remove them from the list. You may only ha
 
 <h3 id="tag_protect">Tag protection</h3>
 
+ ⚠️ **Deprecated**
+GitHub tag protection rules were sunset in February 2024 and are no longer applied.
+This section is retained for historical reference only.
+
 As with branch protection rules, you can enable tag protection rules. These rules allow anyone with write-access to create a tag that matches the rule, but does not allow the tag to be deleted or overwritten.
 
 Tag protection rules follow a simple GLOB format, and support an arbitrary number of tag patterns:


### PR DESCRIPTION
This PR adds a clear deprecation notice to the GitHub tag protection section, clarifying that the feature is no longer supported by GitHub and avoiding confusion for projects using .asf.yaml.
