### PR TITLE
INFRA-27355: add 'terraform-provider' prefix to asfyaml mappings.py

### DIFF
--- a/asfyaml/mappings.py
+++ b/asfyaml/mappings.py
@@ -28,7 +28,7 @@ LDAP_TO_HOSTNAME = {
 }
 
 # Repository filename syntax for inferring project names.
-REPO_RE = re.compile(r"(?:incubator-)?([^-.]+)")
+REPO_RE = re.compile(r"(?:incubator-|terraform-provider-)?([^-.]+)")
 
 # Mailing list overrides. Also to be centralized elsewhere.
 ML_OVERRIDES = {


### PR DESCRIPTION
This will allow for repositories to have a 'terraform-provider-' prefix, thus allowing them to conform to Hashicorp requirements.