### PR TITLE
Add GitHub rulesets support in `.asf.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ It operates on a per-branch basis, meaning you can have different settings for d
       <li><a href="#GHA_build_status">GitHub Actions build status emails</a></li>
       <li><a href="#pages">GitHub Pages</a></li>
       <li><a href="#pull_requests">Pull Request settings</a></li>
+      <li><a href="#copilot_code_review">Copilot code review</a></li>
+      <li><a href="#rulesets">Rulesets</a></li>
       <li><a href="#merge">Merge buttons</a></li>
       <li><a href="#repo_features">Repository features</a></li>
       <li><a href="#repo_meta">Repository metadata</a></li>
@@ -645,6 +647,102 @@ github:
     del_branch_on_merge: true
 ~~~
 
+<h3 id="copilot_code_review">Copilot code review</h3>
+
+Projects can enable automatic [GitHub Copilot code review](https://docs.github.com/en/copilot/how-tos/agents/copilot-code-review/configuring-automatic-code-review-by-copilot) on pull requests:
+
+~~~yaml
+github:
+  copilot_code_review:
+    enabled: true
+    review_drafts: false
+    review_on_push: true
+~~~
+
+This creates (or updates) a repository ruleset named `Copilot Code Review`, scoped to the default branch.
+
+Supported settings:
+
+~~~yaml
+enabled: <boolean>
+review_drafts: <boolean>      # optional, default false
+review_on_push: <boolean>     # optional, default false
+~~~
+
+Set `enabled: false` to disable this behavior. Removing the `copilot_code_review` section also removes an existing Copilot ruleset that was previously managed by `.asf.yaml`.
+
+As an alternative, you can configure Copilot review through [`rulesets`](#rulesets). If both `copilot_code_review`
+and `rulesets` try to manage a ruleset named `Copilot Code Review`, validation fails.
+
+<h3 id="rulesets">Rulesets</h3>
+
+Projects can manage GitHub repository rulesets with a migration-friendly syntax:
+
+~~~yaml
+github:
+  rulesets:
+    - name: "Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "main"
+          - "release/*"
+        excludes: []
+      bypass_users:
+        - "dependabot[bot]"
+      bypass_teams:
+        - "release-managers"
+      required_signatures: true
+      required_linear_history: true
+      required_conversation_resolution: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        require_last_push_approval: false
+        require_code_owner_reviews: true
+        required_approving_review_count: 2
+      required_status_checks:
+        - name: "gh-infra/jenkins"
+          app_slug: "jenkins"
+        - name: "build-and-test"
+          app_slug: -1
+~~~
+
+Notes:
+
+- `enforcement` is hardcoded to `active` for this syntax.
+- `bypass_users` and `bypass_teams` accept user names / team slugs and are resolved to IDs automatically.
+- `required_status_checks.app_slug` accepts either a numeric ID or app slug; slugs are resolved to `integration_id`.
+- `required_status_checks_strict` defaults to `false` (set it to `true` to require branches to be up to date before merge).
+- If `branches`/`refs` is omitted for `type: branch`, it defaults to `~DEFAULT_BRANCH`.
+
+Each entry is converted to the GitHub Rulesets API payload and reconciled by `name`:
+
+- If a ruleset with that name exists, it is updated.
+- If it does not exist, it is created.
+- If a previously managed ruleset name is removed from `.asf.yaml`, it is deleted.
+
+Set `rulesets: ~` (or remove the section) to remove previously managed rulesets.
+
+Advanced use: if needed, you can still provide a raw Rulesets API-style payload (`target`, `conditions`, `rules`, etc.).
+
+### Migrating from `protected_tags`
+
+`protected_tags` is deprecated on GitHub and no longer applied by `.asf.yaml`. Use `rulesets` with `type: tag`
+instead:
+
+~~~yaml
+github:
+  rulesets:
+    - name: "Release tags"
+      type: tag
+      branches:
+        includes:
+          - "rel/*"
+          - "v*.*.*"
+        excludes: []
+      non_fast_forward: true
+~~~
+
 <h3 id="merge">Merge buttons</h3>
 
 Projects can enable/disable the `merge PR` button in the GitHub UI and configure which actions to allow by adding the following configuration (or derivatives thereof):
@@ -726,6 +824,7 @@ github:
 ~~~
 
 **NOTE**: Tag protections have been sunset by GitHub as of 02/12/2024 and will thus not be applied anymore.
+Use [`rulesets`](#rulesets) with `type: tag` (or raw rulesets payloads with `target: tag`) for tag protection policies.
 
 <h3 id="environments">Repository deployment environments</h3>
 

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Projects can manage GitHub repository rulesets using one of two styles:
 - Convenience syntax (recommended)
 - Raw payload syntax (advanced)
 
-#### Convenience syntax (recommended)
+Convenience syntax (recommended):
 
 ~~~yaml
 github:
@@ -694,10 +694,10 @@ github:
           - "main"
           - "release/*"
         excludes: []
-      bypass_users:
-        - "dependabot[bot]"
       bypass_teams:
         - "release-managers"
+      restrict_deletion: true
+      restrict_force_push: true
       required_signatures: true
       required_linear_history: true
       required_conversation_resolution: true
@@ -716,15 +716,17 @@ github:
 Notes:
 
 - `enforcement` is hardcoded to `active` for this syntax.
-- `bypass_users` and `bypass_teams` accept user names / team slugs and are resolved to IDs automatically.
+- `bypass_teams` accepts team slugs and resolves them to IDs automatically.
 - `required_status_checks` accepts either a list of strings (check context, any source) or mappings with `name` and optional `app_slug`.
 - `required_status_checks.app_slug` accepts either a numeric ID or app slug; slugs are resolved to `integration_id`.
 - `required_status_checks_strict` defaults to `false` (set it to `true` to require branches to be up to date before merge).
 - If `branches`/`refs` is omitted for `type: branch`, it defaults to `~DEFAULT_BRANCH`.
-- Convenience syntax always includes `deletion` and `non_fast_forward` rules for safety.
-- `deletion: false` and `non_fast_forward: false` are not allowed in convenience syntax. Use raw payload syntax for custom behavior.
+- `restrict_deletion` and `restrict_force_push` default to `true` in convenience syntax.
+- Set `restrict_deletion: false` and/or `restrict_force_push: false` to disable those rules for a convenience entry.
+- `deletion` and `non_fast_forward` are raw rule types under `rules`, not convenience top-level keys.
+- Convenience entries may intentionally resolve to `rules: []` (for example, while staging migration changes).
 
-#### Validation and reconciliation behavior
+Validation and reconciliation behavior:
 
 - Each `rulesets` entry must use exactly one style: convenience syntax or raw payload syntax.
 - Mixing convenience syntax keys and raw payload syntax keys in the same entry is not supported.
@@ -735,7 +737,7 @@ Notes:
 
 Set `rulesets: ~` (or remove the `rulesets` key) to remove previously managed rulesets managed by `.asf.yaml`.
 
-#### Raw payload syntax (advanced)
+Raw payload syntax (advanced):
 
 Use raw payload syntax (`target`, `conditions`, `rules`, `bypass_actors`, etc.) when you need full Rulesets API control.
 

--- a/README.md
+++ b/README.md
@@ -671,12 +671,18 @@ review_on_push: <boolean>     # optional, default false
 
 Set `enabled: false` to disable this behavior. Removing the `copilot_code_review` section also removes an existing Copilot ruleset that was previously managed by `.asf.yaml`.
 
-As an alternative, you can configure Copilot review through [`rulesets`](#rulesets). If both `copilot_code_review`
-and `rulesets` try to manage a ruleset named `Copilot Code Review`, validation fails.
+As an alternative, you can configure Copilot review through [`rulesets`](#rulesets). Validation fails if both
+`copilot_code_review` and `rulesets` overlap, either by managing a ruleset named `Copilot Code Review`
+or by defining a `copilot_code_review` rule type in `rulesets`.
 
 <h3 id="rulesets">Rulesets</h3>
 
-Projects can manage GitHub repository rulesets with a migration-friendly syntax:
+Projects can manage GitHub repository rulesets using one of two styles:
+
+- Convenience syntax (recommended)
+- Raw payload syntax (advanced)
+
+#### Convenience syntax (recommended)
 
 ~~~yaml
 github:
@@ -711,19 +717,76 @@ Notes:
 
 - `enforcement` is hardcoded to `active` for this syntax.
 - `bypass_users` and `bypass_teams` accept user names / team slugs and are resolved to IDs automatically.
+- `required_status_checks` accepts either a list of strings (check context, any source) or mappings with `name` and optional `app_slug`.
 - `required_status_checks.app_slug` accepts either a numeric ID or app slug; slugs are resolved to `integration_id`.
 - `required_status_checks_strict` defaults to `false` (set it to `true` to require branches to be up to date before merge).
 - If `branches`/`refs` is omitted for `type: branch`, it defaults to `~DEFAULT_BRANCH`.
+- Convenience syntax always includes `deletion` and `non_fast_forward` rules for safety.
+- `deletion: false` and `non_fast_forward: false` are not allowed in convenience syntax. Use raw payload syntax for custom behavior.
 
-Each entry is converted to the GitHub Rulesets API payload and reconciled by `name`:
+#### Validation and reconciliation behavior
 
-- If a ruleset with that name exists, it is updated.
+- Each `rulesets` entry must use exactly one style: convenience syntax or raw payload syntax.
+- Mixing convenience syntax keys and raw payload syntax keys in the same entry is not supported.
+- Ruleset `name` is the reconciliation key and must be unique within `github.rulesets`.
+- If a ruleset with that `name` exists, it is updated.
 - If it does not exist, it is created.
-- If a previously managed ruleset name is removed from `.asf.yaml`, it is deleted.
+- If a previously managed ruleset `name` is removed from `.asf.yaml`, it is deleted.
 
-Set `rulesets: ~` (or remove the section) to remove previously managed rulesets.
+Set `rulesets: ~` (or remove the `rulesets` key) to remove previously managed rulesets managed by `.asf.yaml`.
 
-Advanced use: if needed, you can still provide a raw Rulesets API-style payload (`target`, `conditions`, `rules`, etc.).
+#### Raw payload syntax (advanced)
+
+Use raw payload syntax (`target`, `conditions`, `rules`, `bypass_actors`, etc.) when you need full Rulesets API control.
+
+Raw payload example (including explicit safety rules):
+
+~~~yaml
+github:
+  rulesets:
+    - name: "Custom branch policy"
+      target: branch
+      enforcement: active
+      conditions:
+        ref_name:
+          include:
+            - "~DEFAULT_BRANCH"
+          exclude: []
+      rules:
+        # Restrict deletions: only bypass actors can delete matching refs.
+        - type: deletion
+        # Block force-push/non-fast-forward updates for matching refs.
+        - type: non_fast_forward
+        - type: required_signatures
+        - type: required_linear_history
+        - type: pull_request
+          parameters:
+            dismiss_stale_reviews_on_push: true
+            require_code_owner_review: true
+            require_last_push_approval: false
+            required_approving_review_count: 2
+            required_review_thread_resolution: true
+        - type: required_status_checks
+          parameters:
+            strict_required_status_checks_policy: false
+            required_status_checks:
+              - context: gh-infra/jenkins
+                integration_id: -1
+~~~
+
+Rule summary for the raw payload example:
+
+- `deletion`: Only bypass actors can delete matching branches/tags.
+- `non_fast_forward`: Blocks force-push and other non-fast-forward updates.
+- `required_signatures`: Requires commits with verified signatures.
+- `required_linear_history`: Disallows merge commits on matching refs.
+- `pull_request`: Requires pull requests and controls review policy.
+- `required_status_checks`: Requires specific CI checks before merge/update.
+
+For the full list of supported rules and semantics, see GitHub docs:
+
+- [Available rules for rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
+- [Repository rulesets REST API](https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#get-all-repository-rulesets)
 
 ### Migrating from `protected_tags`
 
@@ -740,7 +803,6 @@ github:
           - "rel/*"
           - "v*.*.*"
         excludes: []
-      non_fast_forward: true
 ~~~
 
 <h3 id="merge">Merge buttons</h3>
@@ -863,7 +925,7 @@ The above example creates two deployment environments, `pypi` and `test-pypi`.
 
 The `environments` section is a dictionary of environment names, each with a dictionary of settings. The settings are:
 
-```yanl
+```yaml
 required_reviewers:
   - id: <string> | <int>
     type: 'User' | 'Team'

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -139,6 +139,17 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
                     strictyaml.Optional("allow_update_branch"): strictyaml.Bool(),
                 }
             ),
+            # Generic repository rulesets
+            strictyaml.Optional("rulesets"): asfyaml.validators.EmptyValue()
+            | strictyaml.Seq(strictyaml.MapPattern(strictyaml.Str(), strictyaml.Any())),
+            # Copilot automatic code review (rulesets API)
+            strictyaml.Optional("copilot_code_review"): strictyaml.Map(
+                {
+                    "enabled": strictyaml.Bool(),
+                    strictyaml.Optional("review_drafts", default=False): strictyaml.Bool(),
+                    strictyaml.Optional("review_on_push", default=False): strictyaml.Bool(),
+                }
+            ),
             # Delete branch on merge
             # TODO: deprecated, use "pull_requests.del_branch_on_merge" instead
             strictyaml.Optional("del_branch_on_merge"): strictyaml.Bool(),
@@ -263,4 +274,6 @@ from . import (
     housekeeping,
     protected_tags,
     deployment_environments,
+    rulesets,
+    copilot_code_review,
 )

--- a/asfyaml/feature/github/copilot_code_review.py
+++ b/asfyaml/feature/github/copilot_code_review.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""GitHub Copilot code review ruleset support."""
+
+from typing import Any
+
+from . import directive, ASFGitHubFeature
+from .rulesets import (
+    COPILOT_RULESET_NAME,
+    COPILOT_RULE_TYPE,
+    get_ruleset_names,
+    reconcile_rulesets,
+    ruleset_has_rule_type,
+)
+
+RULESET_NAME = COPILOT_RULESET_NAME
+
+
+def _build_copilot_ruleset_payload(review_drafts: bool, review_on_push: bool) -> dict[str, Any]:
+    return {
+        "name": RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "copilot_code_review",
+                "parameters": {
+                    "review_draft_pull_requests": review_drafts,
+                    "review_on_push": review_on_push,
+                },
+            }
+        ],
+    }
+
+
+def _rulesets_configure_copilot(rulesets: Any) -> bool:
+    if not isinstance(rulesets, list):
+        return False
+    return any(ruleset_has_rule_type(ruleset, COPILOT_RULE_TYPE) for ruleset in rulesets)
+
+
+@directive
+def copilot_code_review(self: ASFGitHubFeature):
+    copilot = self.yaml.get("copilot_code_review")
+    previous_yaml = self.previous_yaml if isinstance(self.previous_yaml, dict) else {}
+    was_previously_configured = "copilot_code_review" in previous_yaml
+
+    if copilot:
+        enabled = copilot.get("enabled", False)
+        review_drafts = copilot.get("review_drafts", False)
+        review_on_push = copilot.get("review_on_push", False)
+    elif was_previously_configured:
+        enabled = False
+        review_drafts = False
+        review_on_push = False
+    else:
+        return
+
+    if not enabled and not was_previously_configured:
+        return
+
+    configured_rulesets = self.yaml.get("rulesets")
+    ruleset_names = get_ruleset_names(configured_rulesets)
+    rulesets_configure_copilot = _rulesets_configure_copilot(configured_rulesets)
+
+    if enabled and (RULESET_NAME in ruleset_names or rulesets_configure_copilot):
+        raise Exception(
+            "Cannot configure Copilot Code Review via both 'github.copilot_code_review' and 'github.rulesets'."
+        )
+
+    # If generic rulesets owns this name, avoid deleting it during migration from the convenience block.
+    if not enabled and (RULESET_NAME in ruleset_names or rulesets_configure_copilot):
+        return
+
+    if self.noop("copilot_code_review"):
+        return
+
+    desired_rulesets = [_build_copilot_ruleset_payload(review_drafts, review_on_push)] if enabled else []
+    previous_managed_names = {RULESET_NAME} if was_previously_configured else set()
+
+    reconcile_rulesets(self, desired_rulesets, previous_managed_names)

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -25,13 +25,14 @@ from . import directive, ASFGitHubFeature
 COPILOT_RULESET_NAME = "Copilot Code Review"
 COPILOT_RULE_TYPE = "copilot_code_review"
 _RAW_RULESET_KEYS = {"target", "enforcement", "conditions", "rules", "bypass_actors"}
-_FRIENDLY_RULESET_KEYS = {
+_CONVENIENCE_RULESET_KEYS = {
     "type",
     "branches",
     "refs",
     "bypass_users",
     "bypass_teams",
     "bypass_mode",
+    "deletion",
     "required_signatures",
     "required_linear_history",
     "required_conversation_resolution",
@@ -354,6 +355,26 @@ def _is_raw_ruleset_definition(ruleset: dict[str, Any]) -> bool:
     return any(key in ruleset for key in _RAW_RULESET_KEYS)
 
 
+def _validate_always_on_safety_rules(ruleset: dict[str, Any]) -> None:
+    for field_name in ("deletion", "non_fast_forward"):
+        if field_name not in ruleset:
+            continue
+        value = ruleset.get(field_name)
+        try:
+            is_enabled = _expect_bool(value, field_name)
+        except Exception as exc:
+            raise Exception(
+                f"{field_name} must be a boolean. "
+                f"Convenience syntax rulesets always enable '{field_name}'. "
+                "Remove this key or use raw Rulesets API payload syntax if you need custom behavior."
+            ) from exc
+        if not is_enabled:
+            raise Exception(
+                f"Convenience syntax rulesets always enable '{field_name}'. "
+                "Use raw Rulesets API payload syntax if you need to disable it."
+            )
+
+
 def _to_payload_ruleset(
     self: ASFGitHubFeature,
     ruleset: dict[str, Any],
@@ -364,15 +385,17 @@ def _to_payload_ruleset(
     app_cache: dict[str, int],
 ) -> dict[str, Any]:
     if _is_raw_ruleset_definition(ruleset):
-        mixed_keys = _FRIENDLY_RULESET_KEYS.intersection(ruleset)
+        mixed_keys = _CONVENIENCE_RULESET_KEYS.intersection(ruleset)
         if mixed_keys:
             mixed_keys_as_str = ", ".join(sorted(mixed_keys))
-            raise Exception(f"Raw ruleset payload cannot mix friendly keys: {mixed_keys_as_str}")
+            raise Exception(f"Raw ruleset payload cannot mix convenience syntax keys: {mixed_keys_as_str}")
         return dict(ruleset)
 
     target = ruleset.get("type", "branch")
     if not isinstance(target, str) or target not in {"branch", "tag"}:
         raise Exception("ruleset type must be one of: branch, tag")
+
+    _validate_always_on_safety_rules(ruleset)
 
     payload: dict[str, Any] = {
         "name": ruleset["name"],
@@ -400,8 +423,8 @@ def _to_payload_ruleset(
         ruleset.get("required_linear_history"), "required_linear_history"
     ):
         rules.append({"type": "required_linear_history"})
-    if "non_fast_forward" in ruleset and _expect_bool(ruleset.get("non_fast_forward"), "non_fast_forward"):
-        rules.append({"type": "non_fast_forward"})
+    rules.append({"type": "deletion"})
+    rules.append({"type": "non_fast_forward"})
 
     pull_request_rule = _build_pull_request_rule(ruleset)
     if pull_request_rule:
@@ -415,11 +438,6 @@ def _to_payload_ruleset(
     )
     if status_checks_rule:
         rules.append(status_checks_rule)
-
-    if not rules:
-        raise Exception(
-            "Friendly ruleset definitions must define at least one required_* setting or use raw Rulesets API payload keys"
-        )
 
     payload["rules"] = rules
     return payload

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -1,0 +1,539 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""GitHub repository rulesets feature."""
+
+import json
+from typing import Any
+
+from . import directive, ASFGitHubFeature
+
+COPILOT_RULESET_NAME = "Copilot Code Review"
+COPILOT_RULE_TYPE = "copilot_code_review"
+_RAW_RULESET_KEYS = {"target", "enforcement", "conditions", "rules", "bypass_actors"}
+_FRIENDLY_RULESET_KEYS = {
+    "type",
+    "branches",
+    "refs",
+    "bypass_users",
+    "bypass_teams",
+    "bypass_mode",
+    "required_signatures",
+    "required_linear_history",
+    "required_conversation_resolution",
+    "required_pull_request_reviews",
+    "required_status_checks",
+    "required_status_checks_strict",
+    "non_fast_forward",
+}
+
+
+def _rulesets_endpoint(self: ASFGitHubFeature) -> str:
+    return f"/repos/{self.repository.org_id}/{self.repository.name}/rulesets"
+
+
+def _extract_json_payload(response: Any) -> Any:
+    if isinstance(response, (dict, list)):
+        return response
+
+    if isinstance(response, tuple):
+        for item in reversed(response):
+            if isinstance(item, (dict, list)):
+                return item
+        for item in reversed(response):
+            if isinstance(item, str):
+                try:
+                    return json.loads(item)
+                except json.JSONDecodeError:
+                    continue
+
+    return []
+
+
+def list_rulesets(self: ASFGitHubFeature) -> list[dict[str, Any]]:
+    response = self.ghrepo._requester.requestJson("GET", _rulesets_endpoint(self))
+    payload = _extract_json_payload(response)
+    if not isinstance(payload, list):
+        return []
+    return [ruleset for ruleset in payload if isinstance(ruleset, dict)]
+
+
+def get_ruleset_names(rulesets: Any) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(rulesets, list):
+        return names
+
+    for ruleset in rulesets:
+        if not isinstance(ruleset, dict):
+            continue
+        name = ruleset.get("name")
+        if isinstance(name, str) and name.strip():
+            names.add(name)
+
+    return names
+
+
+def ruleset_has_rule_type(ruleset: Any, rule_type: str) -> bool:
+    if not isinstance(ruleset, dict):
+        return False
+    rules = ruleset.get("rules", [])
+    if not isinstance(rules, list):
+        return False
+    return any(isinstance(rule, dict) and rule.get("type") == rule_type for rule in rules)
+
+
+def is_copilot_code_review_enabled(copilot: Any) -> bool:
+    return isinstance(copilot, dict) and copilot.get("enabled", False)
+
+
+def ensure_no_copilot_overlap(desired_rulesets: list[dict[str, Any]], copilot_enabled: bool) -> None:
+    if not copilot_enabled:
+        return
+
+    has_overlap = COPILOT_RULESET_NAME in get_ruleset_names(desired_rulesets) or any(
+        ruleset_has_rule_type(ruleset, COPILOT_RULE_TYPE) for ruleset in desired_rulesets
+    )
+    if has_overlap:
+        raise Exception(
+            "Cannot configure Copilot Code Review via both 'github.copilot_code_review' and 'github.rulesets'."
+        )
+
+
+def _expect_bool(value: Any, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise Exception(f"{field_name} must be a boolean")
+
+
+def _expect_int(value: Any, field_name: str) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized.lstrip("-").isdigit():
+            return int(normalized)
+    raise Exception(f"{field_name} must be an integer")
+
+
+def _expect_string_list(value: Any, field_name: str) -> list[str]:
+    if not isinstance(value, list):
+        raise Exception(f"{field_name} must be a list")
+    if not all(isinstance(v, str) and v.strip() for v in value):
+        raise Exception(f"{field_name} must contain non-empty strings only")
+    return value
+
+
+def _resolve_user_id(self: ASFGitHubFeature, user: Any, *, resolve_references: bool, user_cache: dict[str, int]) -> int:
+    if isinstance(user, int):
+        return user
+    if not isinstance(user, str) or not user.strip():
+        raise Exception("bypass_users entries must be user names or numeric IDs")
+    if not resolve_references:
+        return -1
+    if user not in user_cache:
+        user_cache[user] = self.gh.get_user(user).id
+    return user_cache[user]
+
+
+def _resolve_team_id(self: ASFGitHubFeature, team: Any, *, resolve_references: bool, team_cache: dict[str, int]) -> int:
+    if isinstance(team, int):
+        return team
+    if not isinstance(team, str) or not team.strip():
+        raise Exception("bypass_teams entries must be team slugs or numeric IDs")
+    if not resolve_references:
+        return -1
+    if team not in team_cache:
+        team_cache[team] = self.gh.get_organization(self.repository.org_id).get_team_by_slug(team).id
+    return team_cache[team]
+
+
+def _resolve_integration_id(
+    self: ASFGitHubFeature, app_slug_or_id: Any, *, resolve_references: bool, app_cache: dict[str, int]
+) -> int:
+    if isinstance(app_slug_or_id, int):
+        return app_slug_or_id
+    if isinstance(app_slug_or_id, str):
+        candidate = app_slug_or_id.strip()
+        if not candidate:
+            raise Exception("required_status_checks.app_slug cannot be empty")
+        if candidate.lstrip("-").isdigit():
+            return int(candidate)
+        if not resolve_references:
+            return -1
+        if candidate not in app_cache:
+            response = self.ghrepo._requester.requestJson("GET", f"/apps/{candidate}")
+            payload = _extract_json_payload(response)
+            app_id = payload.get("id") if isinstance(payload, dict) else None
+            if not isinstance(app_id, int):
+                raise Exception(f"Unable to resolve app_slug '{candidate}' to integration_id")
+            app_cache[candidate] = app_id
+        return app_cache[candidate]
+
+    raise Exception("required_status_checks.app_slug must be a string or integer")
+
+
+def _build_ref_name_condition(ruleset: dict[str, Any], target: str) -> dict[str, list[str]]:
+    ref_config = ruleset.get("branches", ruleset.get("refs"))
+    if ref_config is None:
+        if target == "branch":
+            return {"include": ["~DEFAULT_BRANCH"], "exclude": []}
+        raise Exception("Tag rulesets must define branches.includes or refs.includes")
+
+    if not isinstance(ref_config, dict):
+        raise Exception("ruleset branches/refs must be a mapping")
+
+    include_default = ["~DEFAULT_BRANCH"] if target == "branch" else None
+    include = ref_config.get("includes", include_default)
+    if include is None:
+        raise Exception("ruleset branches/refs must define includes")
+
+    exclude = ref_config.get("excludes", [])
+
+    return {
+        "include": _expect_string_list(include, "ruleset branches.includes"),
+        "exclude": _expect_string_list(exclude, "ruleset branches.excludes"),
+    }
+
+
+def _build_bypass_actors(
+    self: ASFGitHubFeature,
+    ruleset: dict[str, Any],
+    *,
+    resolve_references: bool,
+    user_cache: dict[str, int],
+    team_cache: dict[str, int],
+) -> list[dict[str, Any]]:
+    users = ruleset.get("bypass_users", [])
+    teams = ruleset.get("bypass_teams", [])
+    if not isinstance(users, list):
+        raise Exception("bypass_users must be a list")
+    if not isinstance(teams, list):
+        raise Exception("bypass_teams must be a list")
+
+    bypass_mode = ruleset.get("bypass_mode", "always")
+    if not isinstance(bypass_mode, str) or not bypass_mode.strip():
+        raise Exception("bypass_mode must be a non-empty string")
+
+    actors = []
+    for user in users:
+        actors.append(
+            {
+                "actor_id": _resolve_user_id(self, user, resolve_references=resolve_references, user_cache=user_cache),
+                "actor_type": "User",
+                "bypass_mode": bypass_mode,
+            }
+        )
+    for team in teams:
+        actors.append(
+            {
+                "actor_id": _resolve_team_id(self, team, resolve_references=resolve_references, team_cache=team_cache),
+                "actor_type": "Team",
+                "bypass_mode": bypass_mode,
+            }
+        )
+
+    return actors
+
+
+def _build_pull_request_rule(ruleset: dict[str, Any]) -> dict[str, Any] | None:
+    has_reviews = "required_pull_request_reviews" in ruleset
+    has_conversation_resolution = "required_conversation_resolution" in ruleset
+
+    if not has_reviews and not has_conversation_resolution:
+        return None
+
+    required_review_thread_resolution = False
+    if has_conversation_resolution:
+        required_review_thread_resolution = _expect_bool(
+            ruleset.get("required_conversation_resolution"), "required_conversation_resolution"
+        )
+
+    if not has_reviews and not required_review_thread_resolution:
+        return None
+
+    params: dict[str, Any] = {
+        "required_review_thread_resolution": required_review_thread_resolution,
+    }
+
+    if has_reviews:
+        reviews = ruleset.get("required_pull_request_reviews")
+        if not isinstance(reviews, dict):
+            raise Exception("required_pull_request_reviews must be a mapping")
+
+        params["dismiss_stale_reviews_on_push"] = _expect_bool(
+            reviews.get("dismiss_stale_reviews", False),
+            "required_pull_request_reviews.dismiss_stale_reviews",
+        )
+        params["require_last_push_approval"] = _expect_bool(
+            reviews.get("require_last_push_approval", False),
+            "required_pull_request_reviews.require_last_push_approval",
+        )
+        params["require_code_owner_review"] = _expect_bool(
+            reviews.get("require_code_owner_reviews", False),
+            "required_pull_request_reviews.require_code_owner_reviews",
+        )
+        params["required_approving_review_count"] = _expect_int(
+            reviews.get("required_approving_review_count", 0),
+            "required_pull_request_reviews.required_approving_review_count",
+        )
+
+    return {"type": "pull_request", "parameters": params}
+
+
+def _build_status_checks_rule(
+    self: ASFGitHubFeature,
+    ruleset: dict[str, Any],
+    *,
+    resolve_references: bool,
+    app_cache: dict[str, int],
+) -> dict[str, Any] | None:
+    if "required_status_checks" not in ruleset:
+        return None
+
+    checks = ruleset.get("required_status_checks")
+    if not isinstance(checks, list):
+        raise Exception("required_status_checks must be a list")
+    if not checks:
+        return None
+
+    strict = _expect_bool(ruleset.get("required_status_checks_strict", False), "required_status_checks_strict")
+
+    normalized_checks: list[dict[str, Any]] = []
+    for i, check in enumerate(checks):
+        if isinstance(check, str):
+            context = check
+            app_source: Any = -1
+        elif isinstance(check, dict):
+            context = check.get("name", check.get("context"))
+            app_source = check.get("app_slug", check.get("integration_id", -1))
+        else:
+            raise Exception(f"required_status_checks[{i}] must be a string or mapping")
+
+        if not isinstance(context, str) or not context.strip():
+            raise Exception(f"required_status_checks[{i}] must define a non-empty check name")
+
+        normalized_checks.append(
+            {
+                "context": context,
+                "integration_id": _resolve_integration_id(
+                    self, app_source, resolve_references=resolve_references, app_cache=app_cache
+                ),
+            }
+        )
+
+    return {
+        "type": "required_status_checks",
+        "parameters": {
+            "strict_required_status_checks_policy": strict,
+            "required_status_checks": normalized_checks,
+        },
+    }
+
+
+def _is_raw_ruleset_definition(ruleset: dict[str, Any]) -> bool:
+    return any(key in ruleset for key in _RAW_RULESET_KEYS)
+
+
+def _to_payload_ruleset(
+    self: ASFGitHubFeature,
+    ruleset: dict[str, Any],
+    *,
+    resolve_references: bool,
+    user_cache: dict[str, int],
+    team_cache: dict[str, int],
+    app_cache: dict[str, int],
+) -> dict[str, Any]:
+    if _is_raw_ruleset_definition(ruleset):
+        mixed_keys = _FRIENDLY_RULESET_KEYS.intersection(ruleset)
+        if mixed_keys:
+            mixed_keys_as_str = ", ".join(sorted(mixed_keys))
+            raise Exception(f"Raw ruleset payload cannot mix friendly keys: {mixed_keys_as_str}")
+        return dict(ruleset)
+
+    target = ruleset.get("type", "branch")
+    if not isinstance(target, str) or target not in {"branch", "tag"}:
+        raise Exception("ruleset type must be one of: branch, tag")
+
+    payload: dict[str, Any] = {
+        "name": ruleset["name"],
+        "target": target,
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": _build_ref_name_condition(ruleset, target),
+        },
+    }
+
+    bypass_actors = _build_bypass_actors(
+        self,
+        ruleset,
+        resolve_references=resolve_references,
+        user_cache=user_cache,
+        team_cache=team_cache,
+    )
+    if bypass_actors:
+        payload["bypass_actors"] = bypass_actors
+
+    rules: list[dict[str, Any]] = []
+    if "required_signatures" in ruleset and _expect_bool(ruleset.get("required_signatures"), "required_signatures"):
+        rules.append({"type": "required_signatures"})
+    if "required_linear_history" in ruleset and _expect_bool(
+        ruleset.get("required_linear_history"), "required_linear_history"
+    ):
+        rules.append({"type": "required_linear_history"})
+    if "non_fast_forward" in ruleset and _expect_bool(ruleset.get("non_fast_forward"), "non_fast_forward"):
+        rules.append({"type": "non_fast_forward"})
+
+    pull_request_rule = _build_pull_request_rule(ruleset)
+    if pull_request_rule:
+        rules.append(pull_request_rule)
+
+    status_checks_rule = _build_status_checks_rule(
+        self,
+        ruleset,
+        resolve_references=resolve_references,
+        app_cache=app_cache,
+    )
+    if status_checks_rule:
+        rules.append(status_checks_rule)
+
+    if not rules:
+        raise Exception(
+            "Friendly ruleset definitions must define at least one required_* setting or use raw Rulesets API payload keys"
+        )
+
+    payload["rules"] = rules
+    return payload
+
+
+def normalize_rulesets(
+    self: ASFGitHubFeature,
+    rulesets: Any,
+    *,
+    resolve_references: bool = True,
+) -> list[dict[str, Any]]:
+    if rulesets is None:
+        return []
+    if not isinstance(rulesets, list):
+        raise Exception("github.rulesets must be a list of mappings")
+
+    normalized: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    user_cache: dict[str, int] = {}
+    team_cache: dict[str, int] = {}
+    app_cache: dict[str, int] = {}
+
+    for i, ruleset in enumerate(rulesets):
+        if not isinstance(ruleset, dict):
+            raise Exception(f"github.rulesets[{i}] must be a mapping")
+        if "name" not in ruleset:
+            raise Exception(f"github.rulesets[{i}] must define 'name'")
+        name = ruleset.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise Exception(f"github.rulesets[{i}].name must be a non-empty string")
+        if name in seen_names:
+            raise Exception(f"Duplicate ruleset name in github.rulesets: '{name}'")
+
+        seen_names.add(name)
+        normalized.append(
+            _to_payload_ruleset(
+                self,
+                dict(ruleset),
+                resolve_references=resolve_references,
+                user_cache=user_cache,
+                team_cache=team_cache,
+                app_cache=app_cache,
+            )
+        )
+
+    return normalized
+
+
+def reconcile_rulesets(
+    self: ASFGitHubFeature,
+    desired_rulesets: list[dict[str, Any]],
+    previously_managed_names: set[str],
+) -> None:
+    endpoint = _rulesets_endpoint(self)
+    existing_by_name: dict[str, dict[str, Any]] = {}
+
+    existing_rulesets = list_rulesets(self)
+
+    for ruleset in existing_rulesets:
+        name = ruleset.get("name")
+        if isinstance(name, str) and name not in existing_by_name:
+            existing_by_name[name] = ruleset
+
+    desired_names: set[str] = set()
+
+    for ruleset in desired_rulesets:
+        name = ruleset["name"]
+        desired_names.add(name)
+        existing_ruleset = existing_by_name.get(name)
+
+        if existing_ruleset:
+            ruleset_id = existing_ruleset.get("id")
+            if ruleset_id is None:
+                raise Exception(f"Found ruleset '{name}' without an id")
+            print(f"Updating GitHub ruleset '{name}' ({ruleset_id})")
+            self.ghrepo._requester.requestJson("PUT", f"{endpoint}/{ruleset_id}", input=ruleset)
+        else:
+            print(f"Creating GitHub ruleset '{name}'")
+            self.ghrepo._requester.requestJson("POST", endpoint, input=ruleset)
+
+    removed_names = previously_managed_names - desired_names
+    for name in sorted(removed_names):
+        existing_ruleset = existing_by_name.get(name)
+        if not existing_ruleset:
+            continue
+        ruleset_id = existing_ruleset.get("id")
+        if ruleset_id is None:
+            raise Exception(f"Found ruleset '{name}' without an id")
+        print(f"Deleting GitHub ruleset '{name}' ({ruleset_id})")
+        self.ghrepo._requester.requestJson("DELETE", f"{endpoint}/{ruleset_id}")
+
+
+@directive
+def rulesets(self: ASFGitHubFeature):
+    previous_yaml = self.previous_yaml if isinstance(self.previous_yaml, dict) else {}
+    rulesets_configured = "rulesets" in self.yaml
+    was_previously_configured = "rulesets" in previous_yaml
+
+    if not rulesets_configured and not was_previously_configured:
+        return
+
+    noop_mode = self.noop("rulesets")
+    desired_rulesets = (
+        normalize_rulesets(self, self.yaml.get("rulesets"), resolve_references=not noop_mode)
+        if rulesets_configured
+        else []
+    )
+    ensure_no_copilot_overlap(desired_rulesets, is_copilot_code_review_enabled(self.yaml.get("copilot_code_review")))
+
+    previous_managed_names = (
+        get_ruleset_names(previous_yaml.get("rulesets", [])) if was_previously_configured else set()
+    )
+
+    if noop_mode:
+        return
+
+    reconcile_rulesets(self, desired_rulesets, previous_managed_names)

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -29,17 +29,16 @@ _CONVENIENCE_RULESET_KEYS = {
     "type",
     "branches",
     "refs",
-    "bypass_users",
     "bypass_teams",
     "bypass_mode",
-    "deletion",
+    "restrict_deletion",
+    "restrict_force_push",
     "required_signatures",
     "required_linear_history",
     "required_conversation_resolution",
     "required_pull_request_reviews",
     "required_status_checks",
     "required_status_checks_strict",
-    "non_fast_forward",
 }
 
 
@@ -144,18 +143,6 @@ def _expect_string_list(value: Any, field_name: str) -> list[str]:
     return value
 
 
-def _resolve_user_id(self: ASFGitHubFeature, user: Any, *, resolve_references: bool, user_cache: dict[str, int]) -> int:
-    if isinstance(user, int):
-        return user
-    if not isinstance(user, str) or not user.strip():
-        raise Exception("bypass_users entries must be user names or numeric IDs")
-    if not resolve_references:
-        return -1
-    if user not in user_cache:
-        user_cache[user] = self.gh.get_user(user).id
-    return user_cache[user]
-
-
 def _resolve_team_id(self: ASFGitHubFeature, team: Any, *, resolve_references: bool, team_cache: dict[str, int]) -> int:
     if isinstance(team, int):
         return team
@@ -221,13 +208,9 @@ def _build_bypass_actors(
     ruleset: dict[str, Any],
     *,
     resolve_references: bool,
-    user_cache: dict[str, int],
     team_cache: dict[str, int],
 ) -> list[dict[str, Any]]:
-    users = ruleset.get("bypass_users", [])
     teams = ruleset.get("bypass_teams", [])
-    if not isinstance(users, list):
-        raise Exception("bypass_users must be a list")
     if not isinstance(teams, list):
         raise Exception("bypass_teams must be a list")
 
@@ -236,14 +219,6 @@ def _build_bypass_actors(
         raise Exception("bypass_mode must be a non-empty string")
 
     actors = []
-    for user in users:
-        actors.append(
-            {
-                "actor_id": _resolve_user_id(self, user, resolve_references=resolve_references, user_cache=user_cache),
-                "actor_type": "User",
-                "bypass_mode": bypass_mode,
-            }
-        )
     for team in teams:
         actors.append(
             {
@@ -355,24 +330,10 @@ def _is_raw_ruleset_definition(ruleset: dict[str, Any]) -> bool:
     return any(key in ruleset for key in _RAW_RULESET_KEYS)
 
 
-def _validate_always_on_safety_rules(ruleset: dict[str, Any]) -> None:
-    for field_name in ("deletion", "non_fast_forward"):
-        if field_name not in ruleset:
-            continue
-        value = ruleset.get(field_name)
-        try:
-            is_enabled = _expect_bool(value, field_name)
-        except Exception as exc:
-            raise Exception(
-                f"{field_name} must be a boolean. "
-                f"Convenience syntax rulesets always enable '{field_name}'. "
-                "Remove this key or use raw Rulesets API payload syntax if you need custom behavior."
-            ) from exc
-        if not is_enabled:
-            raise Exception(
-                f"Convenience syntax rulesets always enable '{field_name}'. "
-                "Use raw Rulesets API payload syntax if you need to disable it."
-            )
+def _is_safety_rule_enabled(ruleset: dict[str, Any], field_name: str) -> bool:
+    if field_name not in ruleset:
+        return True
+    return _expect_bool(ruleset.get(field_name), field_name)
 
 
 def _to_payload_ruleset(
@@ -380,7 +341,6 @@ def _to_payload_ruleset(
     ruleset: dict[str, Any],
     *,
     resolve_references: bool,
-    user_cache: dict[str, int],
     team_cache: dict[str, int],
     app_cache: dict[str, int],
 ) -> dict[str, Any]:
@@ -395,8 +355,6 @@ def _to_payload_ruleset(
     if not isinstance(target, str) or target not in {"branch", "tag"}:
         raise Exception("ruleset type must be one of: branch, tag")
 
-    _validate_always_on_safety_rules(ruleset)
-
     payload: dict[str, Any] = {
         "name": ruleset["name"],
         "target": target,
@@ -410,7 +368,6 @@ def _to_payload_ruleset(
         self,
         ruleset,
         resolve_references=resolve_references,
-        user_cache=user_cache,
         team_cache=team_cache,
     )
     if bypass_actors:
@@ -423,8 +380,10 @@ def _to_payload_ruleset(
         ruleset.get("required_linear_history"), "required_linear_history"
     ):
         rules.append({"type": "required_linear_history"})
-    rules.append({"type": "deletion"})
-    rules.append({"type": "non_fast_forward"})
+    if _is_safety_rule_enabled(ruleset, "restrict_deletion"):
+        rules.append({"type": "deletion"})
+    if _is_safety_rule_enabled(ruleset, "restrict_force_push"):
+        rules.append({"type": "non_fast_forward"})
 
     pull_request_rule = _build_pull_request_rule(ruleset)
     if pull_request_rule:
@@ -456,7 +415,6 @@ def normalize_rulesets(
 
     normalized: list[dict[str, Any]] = []
     seen_names: set[str] = set()
-    user_cache: dict[str, int] = {}
     team_cache: dict[str, int] = {}
     app_cache: dict[str, int] = {}
 
@@ -477,7 +435,6 @@ def normalize_rulesets(
                 self,
                 dict(ruleset),
                 resolve_references=resolve_references,
-                user_cache=user_cache,
                 team_cache=team_cache,
                 app_cache=app_cache,
             )

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -489,6 +489,8 @@ def reconcile_rulesets(
 
 @directive
 def rulesets(self: ASFGitHubFeature):
+    if "github_rulesets" not in self.instance.environments_enabled:
+        return
     previous_yaml = self.previous_yaml if isinstance(self.previous_yaml, dict) else {}
     rulesets_configured = "rulesets" in self.yaml
     was_previously_configured = "rulesets" in previous_yaml

--- a/tests/github_copilot_code_review.py
+++ b/tests/github_copilot_code_review.py
@@ -1,0 +1,301 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for .asf.yaml GitHub Copilot code review feature."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import asfyaml.asfyaml
+import asfyaml.dataobjects
+from asfyaml.feature.github.copilot_code_review import (
+    RULESET_NAME,
+    _build_copilot_ruleset_payload,
+    copilot_code_review,
+)
+from helpers import YamlTest
+
+# Set .asf.yaml to debug mode
+asfyaml.asfyaml.DEBUG = True
+
+
+valid_copilot_code_review = YamlTest(
+    None,
+    None,
+    """
+github:
+    copilot_code_review:
+      enabled: true
+      review_drafts: false
+      review_on_push: true
+""",
+)
+
+invalid_copilot_code_review = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "when expecting a bool",
+    """
+github:
+    copilot_code_review:
+      enabled:
+        - true
+""",
+)
+
+
+class FakeRequester:
+    def __init__(self, rulesets: list[dict[str, Any]] | None = None):
+        self.rulesets = rulesets or []
+        self.calls: list[dict[str, Any]] = []
+
+    def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
+        self.calls.append({"method": method, "url": url, "input": input})
+        if method == "GET":
+            return 200, {}, self.rulesets
+        return 200, {}, {}
+
+
+class FakeFeature:
+    def __init__(
+        self,
+        *,
+        yaml: dict[str, Any],
+        previous_yaml: dict[str, Any],
+        requester: FakeRequester,
+        noop_enabled: bool = False,
+    ):
+        self.yaml = yaml
+        self.previous_yaml = previous_yaml
+        self.repository = SimpleNamespace(org_id="apache", name="infrastructure-asfyaml")
+        self.ghrepo = SimpleNamespace(_requester=requester)
+        self._noop_enabled = noop_enabled
+
+    def noop(self, directive: str) -> bool:
+        if self._noop_enabled:
+            print(f"[github::{directive}] Not applying changes, noop mode active.")
+            return True
+        return False
+
+
+def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
+    print("[github] Testing copilot code review")
+
+    tests_to_run = (
+        valid_copilot_code_review,
+        invalid_copilot_code_review,
+    )
+
+    for test in tests_to_run:
+        with test.ctx():
+            a = asfyaml.asfyaml.ASFYamlInstance(
+                repo=test_repo, committer="humbedooh", config_data=test.yaml, branch=asfyaml.dataobjects.DEFAULT_BRANCH
+            )
+            a.environments_enabled.add("noop")
+            a.no_cache = True
+            a.run_parts()
+
+
+def test_enable_copilot_code_review_creates_ruleset():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"copilot_code_review": {"enabled": True, "review_drafts": False, "review_on_push": True}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "POST"]
+    assert requester.calls[1]["url"] == "/repos/apache/infrastructure-asfyaml/rulesets"
+    assert requester.calls[1]["input"] == _build_copilot_ruleset_payload(False, True)
+
+
+def test_enable_copilot_code_review_updates_existing_ruleset():
+    existing_rulesets = [
+        {
+            "id": 73,
+            "name": RULESET_NAME,
+            "rules": [{"type": "copilot_code_review", "parameters": {}}],
+        }
+    ]
+    requester = FakeRequester(rulesets=existing_rulesets)
+    feature = FakeFeature(
+        yaml={"copilot_code_review": {"enabled": True, "review_drafts": True, "review_on_push": False}},
+        previous_yaml={"copilot_code_review": {"enabled": True, "review_drafts": False, "review_on_push": False}},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PUT"]
+    assert requester.calls[1]["url"] == "/repos/apache/infrastructure-asfyaml/rulesets/73"
+    assert requester.calls[1]["input"] == _build_copilot_ruleset_payload(True, False)
+
+
+def test_disable_copilot_code_review_deletes_existing_ruleset():
+    existing_rulesets = [
+        {
+            "id": 89,
+            "name": RULESET_NAME,
+            "rules": [{"type": "copilot_code_review", "parameters": {}}],
+        }
+    ]
+    requester = FakeRequester(rulesets=existing_rulesets)
+    feature = FakeFeature(
+        yaml={"copilot_code_review": {"enabled": False}},
+        previous_yaml={"copilot_code_review": {"enabled": True}},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "DELETE"]
+    assert requester.calls[1]["url"] == "/repos/apache/infrastructure-asfyaml/rulesets/89"
+
+
+def test_removed_copilot_code_review_section_deletes_existing_ruleset():
+    existing_rulesets = [
+        {
+            "id": 101,
+            "name": RULESET_NAME,
+            "rules": [{"type": "copilot_code_review", "parameters": {}}],
+        }
+    ]
+    requester = FakeRequester(rulesets=existing_rulesets)
+    feature = FakeFeature(
+        yaml={},
+        previous_yaml={"copilot_code_review": {"enabled": True}},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "DELETE"]
+    assert requester.calls[1]["url"] == "/repos/apache/infrastructure-asfyaml/rulesets/101"
+
+
+def test_noop_mode_does_not_call_api(capsys):
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"copilot_code_review": {"enabled": True}},
+        previous_yaml={},
+        requester=requester,
+        noop_enabled=True,
+    )
+
+    copilot_code_review(feature)
+
+    captured = capsys.readouterr()
+    assert "noop mode active" in captured.out
+    assert requester.calls == []
+
+
+def test_copilot_conflict_with_generic_rulesets_entry():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "copilot_code_review": {"enabled": True},
+            "rulesets": [{"name": RULESET_NAME}],
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, "Cannot configure Copilot Code Review via both", "").ctx():
+        copilot_code_review(feature)
+
+    assert requester.calls == []
+
+
+def test_copilot_conflict_with_generic_rulesets_copilot_rule_type():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "copilot_code_review": {"enabled": True},
+            "rulesets": [
+                {
+                    "name": "custom",
+                    "rules": [{"type": "copilot_code_review", "parameters": {"review_draft_pull_requests": True}}],
+                }
+            ],
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, "Cannot configure Copilot Code Review via both", "").ctx():
+        copilot_code_review(feature)
+
+    assert requester.calls == []
+
+
+def test_copilot_disable_does_not_delete_when_rulesets_manage_name():
+    requester = FakeRequester(rulesets=[{"id": 77, "name": RULESET_NAME, "rules": []}])
+    feature = FakeFeature(
+        yaml={
+            "copilot_code_review": {"enabled": False},
+            "rulesets": [{"name": RULESET_NAME}],
+        },
+        previous_yaml={"copilot_code_review": {"enabled": True}},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert requester.calls == []
+
+
+def test_copilot_disable_does_not_delete_when_rulesets_manage_copilot_rule_type():
+    requester = FakeRequester(rulesets=[{"id": 78, "name": "Copilot custom name", "rules": []}])
+    feature = FakeFeature(
+        yaml={
+            "copilot_code_review": {"enabled": False},
+            "rulesets": [{"name": "my-copilot", "rules": [{"type": "copilot_code_review"}]}],
+        },
+        previous_yaml={"copilot_code_review": {"enabled": True}},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert requester.calls == []
+
+
+def test_removed_copilot_section_does_not_delete_when_rulesets_manage_name():
+    requester = FakeRequester(rulesets=[{"id": 88, "name": RULESET_NAME, "rules": []}])
+    feature = FakeFeature(
+        yaml={"rulesets": [{"name": RULESET_NAME}]},
+        previous_yaml={"copilot_code_review": {"enabled": True}},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert requester.calls == []
+
+
+def test_removed_copilot_section_does_not_delete_when_rulesets_manage_copilot_rule_type():
+    requester = FakeRequester(rulesets=[{"id": 89, "name": "Copilot custom name", "rules": []}])
+    feature = FakeFeature(
+        yaml={"rulesets": [{"name": "my-copilot", "rules": [{"type": "copilot_code_review"}]}]},
+        previous_yaml={"copilot_code_review": {"enabled": True}},
+        requester=requester,
+    )
+
+    copilot_code_review(feature)
+
+    assert requester.calls == []

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -250,9 +250,8 @@ def test_rulesets_convenience_syntax_creates_ruleset():
     assert status_rule["parameters"]["strict_required_status_checks_policy"] is False
 
 
-def test_rulesets_convenience_resolves_bypass_and_app_slug():
+def test_rulesets_convenience_resolves_bypass_team_and_app_slug():
     fake_gh = SimpleNamespace(
-        get_user=lambda username: SimpleNamespace(id={"alice": 101}[username]),
         get_organization=lambda _org: SimpleNamespace(
             get_team_by_slug=lambda slug: SimpleNamespace(id={"infra": 202}[slug])
         ),
@@ -265,7 +264,6 @@ def test_rulesets_convenience_resolves_bypass_and_app_slug():
                     "name": "Branch Protection",
                     "type": "branch",
                     "required_signatures": True,
-                    "bypass_users": ["alice"],
                     "bypass_teams": ["infra"],
                     "required_status_checks": [{"name": "gh-infra/jenkins", "app_slug": "jenkins"}],
                 }
@@ -281,7 +279,6 @@ def test_rulesets_convenience_resolves_bypass_and_app_slug():
     post_call = next(call for call in requester.calls if call["method"] == "POST")
     payload = post_call["input"]
     assert payload["bypass_actors"] == [
-        {"actor_id": 101, "actor_type": "User", "bypass_mode": "always"},
         {"actor_id": 202, "actor_type": "Team", "bypass_mode": "always"},
     ]
     status_rule = next(rule for rule in payload["rules"] if rule["type"] == "required_status_checks")
@@ -290,7 +287,7 @@ def test_rulesets_convenience_resolves_bypass_and_app_slug():
     ]
 
 
-def test_rulesets_convenience_tag_non_fast_forward_rule():
+def test_rulesets_convenience_tag_restrict_force_push_rule():
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -299,7 +296,7 @@ def test_rulesets_convenience_tag_non_fast_forward_rule():
                     "name": "Release tags",
                     "type": "tag",
                     "branches": {"includes": ["v*.*.*"], "excludes": []},
-                    "non_fast_forward": True,
+                    "restrict_force_push": True,
                 }
             ]
         },
@@ -338,7 +335,7 @@ def test_rulesets_convenience_minimal_config_includes_safety_rules():
     assert rule_types == ["deletion", "non_fast_forward"]
 
 
-def test_rulesets_convenience_disallow_deletion_false():
+def test_rulesets_convenience_restrict_deletion_false_disables_rule():
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -346,7 +343,7 @@ def test_rulesets_convenience_disallow_deletion_false():
                 {
                     "name": "Branch Protection",
                     "type": "branch",
-                    "deletion": False,
+                    "restrict_deletion": False,
                     "required_signatures": True,
                 }
             ]
@@ -355,11 +352,15 @@ def test_rulesets_convenience_disallow_deletion_false():
         requester=requester,
     )
 
-    with pytest.raises(Exception, match="Convenience syntax rulesets always enable 'deletion'"):
-        configure_rulesets(feature)
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "deletion" not in rule_types
+    assert "non_fast_forward" in rule_types
 
 
-def test_rulesets_convenience_disallow_non_fast_forward_false():
+def test_rulesets_convenience_restrict_force_push_false_disables_rule():
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -367,7 +368,7 @@ def test_rulesets_convenience_disallow_non_fast_forward_false():
                 {
                     "name": "Branch Protection",
                     "type": "branch",
-                    "non_fast_forward": False,
+                    "restrict_force_push": False,
                     "required_signatures": True,
                 }
             ]
@@ -376,17 +377,44 @@ def test_rulesets_convenience_disallow_non_fast_forward_false():
         requester=requester,
     )
 
-    with pytest.raises(Exception, match="Convenience syntax rulesets always enable 'non_fast_forward'"):
-        configure_rulesets(feature)
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "deletion" in rule_types
+    assert "non_fast_forward" not in rule_types
+
+
+def test_rulesets_convenience_both_safety_rules_false_allows_empty_rules():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "restrict_deletion": False,
+                    "restrict_force_push": False,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    assert payload["rules"] == []
 
 
 @pytest.mark.parametrize(
     ("field_name", "field_value"),
     [
-        ("deletion", True),
-        ("deletion", "true"),
-        ("non_fast_forward", True),
-        ("non_fast_forward", "true"),
+        ("restrict_deletion", True),
+        ("restrict_deletion", "true"),
+        ("restrict_force_push", True),
+        ("restrict_force_push", "true"),
     ],
 )
 def test_rulesets_convenience_allow_explicit_safety_true(field_name: str, field_value: bool | str):
@@ -414,7 +442,10 @@ def test_rulesets_convenience_allow_explicit_safety_true(field_name: str, field_
     assert "non_fast_forward" in rule_types
 
 
-@pytest.mark.parametrize("field_name", ["deletion", "non_fast_forward"])
+@pytest.mark.parametrize(
+    "field_name",
+    ["restrict_deletion", "restrict_force_push"],
+)
 def test_rulesets_convenience_reject_invalid_safety_type(field_name: str):
     requester = FakeRequester()
     feature = FakeFeature(

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -52,7 +52,7 @@ github:
 """,
 )
 
-valid_rulesets_friendly = YamlTest(
+valid_rulesets_convenience = YamlTest(
     None,
     None,
     """
@@ -88,7 +88,7 @@ github:
 """,
 )
 
-invalid_rulesets_friendly_bad_bool = YamlTest(
+invalid_rulesets_convenience_bad_bool = YamlTest(
     asfyaml.asfyaml.ASFYAMLException,
     "required_signatures must be a boolean",
     """
@@ -171,9 +171,9 @@ def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
 
     tests_to_run = (
         valid_rulesets,
-        valid_rulesets_friendly,
+        valid_rulesets_convenience,
         invalid_rulesets_not_sequence,
-        invalid_rulesets_friendly_bad_bool,
+        invalid_rulesets_convenience_bad_bool,
     )
 
     for test in tests_to_run:
@@ -202,7 +202,7 @@ def test_rulesets_create_new_ruleset():
     assert requester.calls[1]["input"] == payload
 
 
-def test_rulesets_friendly_syntax_creates_ruleset():
+def test_rulesets_convenience_syntax_creates_ruleset():
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -239,6 +239,8 @@ def test_rulesets_friendly_syntax_creates_ruleset():
     assert payload["conditions"]["ref_name"]["exclude"] == []
 
     rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "deletion" in rule_types
+    assert "non_fast_forward" in rule_types
     assert "required_signatures" in rule_types
     assert "required_linear_history" in rule_types
     assert "pull_request" in rule_types
@@ -248,7 +250,7 @@ def test_rulesets_friendly_syntax_creates_ruleset():
     assert status_rule["parameters"]["strict_required_status_checks_policy"] is False
 
 
-def test_rulesets_friendly_resolves_bypass_and_app_slug():
+def test_rulesets_convenience_resolves_bypass_and_app_slug():
     fake_gh = SimpleNamespace(
         get_user=lambda username: SimpleNamespace(id={"alice": 101}[username]),
         get_organization=lambda _org: SimpleNamespace(
@@ -288,7 +290,7 @@ def test_rulesets_friendly_resolves_bypass_and_app_slug():
     ]
 
 
-def test_rulesets_friendly_tag_non_fast_forward_rule():
+def test_rulesets_convenience_tag_non_fast_forward_rule():
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -310,10 +312,131 @@ def test_rulesets_friendly_tag_non_fast_forward_rule():
     payload = requester.calls[1]["input"]
     assert payload["target"] == "tag"
     rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "deletion" in rule_types
     assert "non_fast_forward" in rule_types
 
 
-def test_rulesets_friendly_conversation_resolution_false_does_not_add_pull_request_rule():
+def test_rulesets_convenience_minimal_config_includes_safety_rules():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Safety defaults only",
+                    "type": "branch",
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert rule_types == ["deletion", "non_fast_forward"]
+
+
+def test_rulesets_convenience_disallow_deletion_false():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "deletion": False,
+                    "required_signatures": True,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match="Convenience syntax rulesets always enable 'deletion'"):
+        configure_rulesets(feature)
+
+
+def test_rulesets_convenience_disallow_non_fast_forward_false():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "non_fast_forward": False,
+                    "required_signatures": True,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match="Convenience syntax rulesets always enable 'non_fast_forward'"):
+        configure_rulesets(feature)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("deletion", True),
+        ("deletion", "true"),
+        ("non_fast_forward", True),
+        ("non_fast_forward", "true"),
+    ],
+)
+def test_rulesets_convenience_allow_explicit_safety_true(field_name: str, field_value: bool | str):
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    field_name: field_value,
+                    "required_signatures": True,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "deletion" in rule_types
+    assert "non_fast_forward" in rule_types
+
+
+@pytest.mark.parametrize("field_name", ["deletion", "non_fast_forward"])
+def test_rulesets_convenience_reject_invalid_safety_type(field_name: str):
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    field_name: "no",
+                    "required_signatures": True,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match=rf"{field_name} must be a boolean"):
+        configure_rulesets(feature)
+
+
+def test_rulesets_convenience_conversation_resolution_false_does_not_add_pull_request_rule():
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -435,7 +558,7 @@ def test_rulesets_duplicate_names_raise():
         configure_rulesets(feature)
 
 
-def test_rulesets_mixed_raw_and_friendly_keys_raise():
+def test_rulesets_mixed_raw_and_convenience_keys_raise():
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -452,5 +575,5 @@ def test_rulesets_mixed_raw_and_friendly_keys_raise():
         requester=requester,
     )
 
-    with pytest.raises(Exception, match="Raw ruleset payload cannot mix friendly keys"):
+    with pytest.raises(Exception, match="Raw ruleset payload cannot mix convenience syntax keys"):
         configure_rulesets(feature)

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -158,6 +158,7 @@ class FakeFeature:
         self.ghrepo = SimpleNamespace(_requester=requester)
         self.gh = gh
         self._noop_enabled = noop_enabled
+        self.instance = SimpleNamespace(environments_enabled={"production", "github_rulesets"})
 
     def noop(self, directive: str) -> bool:
         if self._noop_enabled:
@@ -182,6 +183,7 @@ def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
                 repo=test_repo, committer="humbedooh", config_data=test.yaml, branch=asfyaml.dataobjects.DEFAULT_BRANCH
             )
             a.environments_enabled.add("noop")
+            a.environments_enabled.add("github_rulesets")
             a.no_cache = True
             a.run_parts()
 

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -1,0 +1,456 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for .asf.yaml GitHub rulesets feature."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import asfyaml.asfyaml
+import asfyaml.dataobjects
+import pytest
+from asfyaml.feature.github.rulesets import COPILOT_RULESET_NAME, rulesets as configure_rulesets
+from helpers import YamlTest
+
+# Set .asf.yaml to debug mode
+asfyaml.asfyaml.DEBUG = True
+
+
+valid_rulesets = YamlTest(
+    None,
+    None,
+    """
+github:
+    rulesets:
+      - name: "Default branch checks"
+        target: branch
+        enforcement: active
+        conditions:
+          ref_name:
+            include:
+              - "~DEFAULT_BRANCH"
+            exclude: []
+        rules:
+          - type: required_status_checks
+            parameters:
+              strict_required_status_checks_policy: true
+              required_status_checks: []
+""",
+)
+
+valid_rulesets_friendly = YamlTest(
+    None,
+    None,
+    """
+github:
+    rulesets:
+      - name: "Branch Protection"
+        type: branch
+        branches:
+          includes:
+            - "main"
+          excludes: []
+        required_signatures: true
+        required_linear_history: true
+        required_conversation_resolution: true
+        required_pull_request_reviews:
+          dismiss_stale_reviews: true
+          require_last_push_approval: false
+          require_code_owner_reviews: true
+          required_approving_review_count: 2
+        required_status_checks:
+          - name: "gh-infra/jenkins"
+            app_slug: -1
+""",
+)
+
+invalid_rulesets_not_sequence = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "when expecting a sequence",
+    """
+github:
+    rulesets:
+      name: "Not a list"
+""",
+)
+
+invalid_rulesets_friendly_bad_bool = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "required_signatures must be a boolean",
+    """
+github:
+    rulesets:
+      - name: "Branch Protection"
+        required_signatures: "yes"
+""",
+)
+
+
+def _build_ruleset_payload(name: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "strict_required_status_checks_policy": True,
+                    "required_status_checks": [],
+                },
+            }
+        ],
+    }
+
+
+class FakeRequester:
+    def __init__(self, rulesets: list[dict[str, Any]] | None = None, apps: dict[str, int] | None = None):
+        self.rulesets = rulesets or []
+        self.apps = apps or {}
+        self.calls: list[dict[str, Any]] = []
+
+    def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
+        self.calls.append({"method": method, "url": url, "input": input})
+        if method == "GET" and url.startswith("/apps/"):
+            app_slug = url.rsplit("/", 1)[-1]
+            app_id = self.apps.get(app_slug)
+            if app_id is None:
+                return 404, {}, {}
+            return 200, {}, {"id": app_id}
+        if method == "GET":
+            return 200, {}, self.rulesets
+        return 200, {}, {}
+
+
+class FakeFeature:
+    def __init__(
+        self,
+        *,
+        yaml: dict[str, Any],
+        previous_yaml: dict[str, Any],
+        requester: FakeRequester,
+        gh: Any | None = None,
+        noop_enabled: bool = False,
+    ):
+        self.yaml = yaml
+        self.previous_yaml = previous_yaml
+        self.repository = SimpleNamespace(org_id="apache", name="infrastructure-asfyaml")
+        self.ghrepo = SimpleNamespace(_requester=requester)
+        self.gh = gh
+        self._noop_enabled = noop_enabled
+
+    def noop(self, directive: str) -> bool:
+        if self._noop_enabled:
+            print(f"[github::{directive}] Not applying changes, noop mode active.")
+            return True
+        return False
+
+
+def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
+    print("[github] Testing rulesets")
+
+    tests_to_run = (
+        valid_rulesets,
+        valid_rulesets_friendly,
+        invalid_rulesets_not_sequence,
+        invalid_rulesets_friendly_bad_bool,
+    )
+
+    for test in tests_to_run:
+        with test.ctx():
+            a = asfyaml.asfyaml.ASFYamlInstance(
+                repo=test_repo, committer="humbedooh", config_data=test.yaml, branch=asfyaml.dataobjects.DEFAULT_BRANCH
+            )
+            a.environments_enabled.add("noop")
+            a.no_cache = True
+            a.run_parts()
+
+
+def test_rulesets_create_new_ruleset():
+    payload = _build_ruleset_payload("Default branch checks")
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"rulesets": [payload]},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "POST"]
+    assert requester.calls[1]["url"] == "/repos/apache/infrastructure-asfyaml/rulesets"
+    assert requester.calls[1]["input"] == payload
+
+
+def test_rulesets_friendly_syntax_creates_ruleset():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "branches": {"includes": ["main"], "excludes": []},
+                    "required_signatures": True,
+                    "required_linear_history": True,
+                    "required_conversation_resolution": True,
+                    "required_pull_request_reviews": {
+                        "dismiss_stale_reviews": True,
+                        "require_last_push_approval": False,
+                        "require_code_owner_reviews": True,
+                        "required_approving_review_count": 2,
+                    },
+                    "required_status_checks": [{"name": "gh-infra/jenkins", "app_slug": -1}],
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "POST"]
+    payload = requester.calls[1]["input"]
+    assert payload["name"] == "Branch Protection"
+    assert payload["target"] == "branch"
+    assert payload["enforcement"] == "active"
+    assert payload["conditions"]["ref_name"]["include"] == ["main"]
+    assert payload["conditions"]["ref_name"]["exclude"] == []
+
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "required_signatures" in rule_types
+    assert "required_linear_history" in rule_types
+    assert "pull_request" in rule_types
+    assert "required_status_checks" in rule_types
+
+    status_rule = next(rule for rule in payload["rules"] if rule["type"] == "required_status_checks")
+    assert status_rule["parameters"]["strict_required_status_checks_policy"] is False
+
+
+def test_rulesets_friendly_resolves_bypass_and_app_slug():
+    fake_gh = SimpleNamespace(
+        get_user=lambda username: SimpleNamespace(id={"alice": 101}[username]),
+        get_organization=lambda _org: SimpleNamespace(
+            get_team_by_slug=lambda slug: SimpleNamespace(id={"infra": 202}[slug])
+        ),
+    )
+    requester = FakeRequester(apps={"jenkins": 303})
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "required_signatures": True,
+                    "bypass_users": ["alice"],
+                    "bypass_teams": ["infra"],
+                    "required_status_checks": [{"name": "gh-infra/jenkins", "app_slug": "jenkins"}],
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+        gh=fake_gh,
+    )
+
+    configure_rulesets(feature)
+
+    post_call = next(call for call in requester.calls if call["method"] == "POST")
+    payload = post_call["input"]
+    assert payload["bypass_actors"] == [
+        {"actor_id": 101, "actor_type": "User", "bypass_mode": "always"},
+        {"actor_id": 202, "actor_type": "Team", "bypass_mode": "always"},
+    ]
+    status_rule = next(rule for rule in payload["rules"] if rule["type"] == "required_status_checks")
+    assert status_rule["parameters"]["required_status_checks"] == [
+        {"context": "gh-infra/jenkins", "integration_id": 303}
+    ]
+
+
+def test_rulesets_friendly_tag_non_fast_forward_rule():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Release tags",
+                    "type": "tag",
+                    "branches": {"includes": ["v*.*.*"], "excludes": []},
+                    "non_fast_forward": True,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    assert payload["target"] == "tag"
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "non_fast_forward" in rule_types
+
+
+def test_rulesets_friendly_conversation_resolution_false_does_not_add_pull_request_rule():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "required_signatures": True,
+                    "required_conversation_resolution": False,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert "required_signatures" in rule_types
+    assert "pull_request" not in rule_types
+
+
+def test_rulesets_update_existing_ruleset():
+    payload = _build_ruleset_payload("Default branch checks")
+    requester = FakeRequester(rulesets=[{"id": 22, "name": payload["name"], "rules": []}])
+    feature = FakeFeature(
+        yaml={"rulesets": [payload]},
+        previous_yaml={"rulesets": [payload]},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PUT"]
+    assert requester.calls[1]["url"] == "/repos/apache/infrastructure-asfyaml/rulesets/22"
+    assert requester.calls[1]["input"] == payload
+
+
+def test_rulesets_removed_section_deletes_previously_managed_rulesets():
+    existing = [{"id": 31, "name": "Default branch checks", "rules": []}]
+    requester = FakeRequester(rulesets=existing)
+    feature = FakeFeature(
+        yaml={},
+        previous_yaml={"rulesets": [_build_ruleset_payload("Default branch checks")]},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "DELETE"]
+    assert requester.calls[1]["url"] == "/repos/apache/infrastructure-asfyaml/rulesets/31"
+
+
+def test_rulesets_noop_mode_does_not_call_api(capsys):
+    payload = _build_ruleset_payload("Default branch checks")
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"rulesets": [payload]},
+        previous_yaml={},
+        requester=requester,
+        noop_enabled=True,
+    )
+
+    configure_rulesets(feature)
+
+    captured = capsys.readouterr()
+    assert "noop mode active" in captured.out
+    assert requester.calls == []
+
+
+def test_rulesets_conflict_with_copilot_convenience_block():
+    payload = _build_ruleset_payload(COPILOT_RULESET_NAME)
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"rulesets": [payload], "copilot_code_review": {"enabled": True}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match="Cannot configure Copilot Code Review via both"):
+        configure_rulesets(feature)
+
+    assert requester.calls == []
+
+
+def test_rulesets_conflict_with_copilot_when_ruleset_contains_copilot_rule():
+    payload = {
+        "name": "Custom copilot ruleset",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "copilot_code_review", "parameters": {"review_draft_pull_requests": False}}],
+    }
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"rulesets": [payload], "copilot_code_review": {"enabled": True}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match="Cannot configure Copilot Code Review via both"):
+        configure_rulesets(feature)
+
+    assert requester.calls == []
+
+
+def test_rulesets_duplicate_names_raise():
+    payload = _build_ruleset_payload("Duplicate name")
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"rulesets": [payload, payload]},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match=r"Duplicate ruleset name in github\.rulesets"):
+        configure_rulesets(feature)
+
+
+def test_rulesets_mixed_raw_and_friendly_keys_raise():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "target": "branch",
+                    "rules": [{"type": "required_signatures"}],
+                    "required_signatures": True,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match="Raw ruleset payload cannot mix friendly keys"):
+        configure_rulesets(feature)


### PR DESCRIPTION
This adds first-class `github.rulesets` support in `.asf.yaml` so repositories can declaratively manage repository rulesets via the GitHub Rulesets API.

- Adds generic ruleset reconciliation by `name` (create/update/delete, with no-op when unchanged).
- Supports two entry styles for `github.rulesets`:
  - convenience syntax (`type`, `branches`/`tags`, `bypass_teams`, `required_*`, safety toggles, etc.)
  - raw payload syntax (`target`, `enforcement`, `conditions`, `rules`, `bypass_actors`) for advanced use.
- In convenience syntax, `restrict_deletion` and `restrict_force_push` default to `true`, and can be intentionally overridden with explicit `false`.
- Convenience entries may intentionally resolve to `rules: []`.
- Rejects mixed-style entries (raw + convenience keys in the same ruleset item) with a clear validation error.
- Keeps `github.copilot_code_review` as a convenience alias on top of shared rulesets reconciliation logic, and blocks conflicts when Copilot is also managed via `github.rulesets`.

Design decisions:
- Keep both convenience and raw payload styles: convenience covers common `.asf.yaml` cases and migration paths, while raw payload preserves full GitHub API fidelity for advanced or newly introduced rule types.
- Default safety behavior with explicit override: convenience syntax defaults safety to on, but supports explicit opt-out for intentional policy differences.
- Allow empty `rules` payloads: GitHub create/update ruleset APIs accept this shape, and it supports staged migration and incremental rollout workflows.
- Reject `bypass_users` in convenience syntax: repository ruleset bypass actors do not support `actor_type: User` in GitHub's REST schema. To avoid invalid payloads or lossy remapping semantics, convenience mode supports `bypass_teams`; use raw `bypass_actors` for advanced actor control.

Example (convenience syntax):

~~~yaml
github:
  rulesets:
    - name: "Branch Protection"
      type: branch
      branches:
        includes:
          - "main"
      restrict_deletion: false
      restrict_force_push: true
      bypass_teams:
        - "release-managers"
      required_pull_request_reviews:
        required_approving_review_count: 2
      required_status_checks:
        - name: "build-and-test"
          app_slug: -1
~~~

closes #49

Validated with:
`uvx --with pyyaml --with strictyaml --with easydict --with asfpy --with "PyGithub>=2.5.0,<3" --with pytest pytest tests/github_*.py -q`