### PR TITLE
Follow-up fixes for the GitHub rulesets feature

### DIFF
--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -50,15 +50,14 @@ def _rulesets_endpoint(self: ASFGitHubFeature) -> str:
 
 def list_rulesets(self: ASFGitHubFeature) -> list[dict[str, Any]]:
     status, _headers, body = self.ghrepo._requester.requestJson("GET", _rulesets_endpoint(self))
-    match status:
-        case 200:
-            pass
-        case 404:
-            raise Exception(f"Repository '{self.repository.org_id}/{self.repository.name}' not found or not accessible")
-        case 500:
-            raise Exception("GitHub server error while listing rulesets")
-        case _:
-            raise Exception(f"Unexpected response while listing rulesets: HTTP {status}")
+    _check_ruleset_response(
+        status,
+        200,
+        f"Repository '{self.repository.org_id}/{self.repository.name}' not found or not accessible",
+        "while listing rulesets",
+        body,
+        has_422=False,
+    )
     payload = json.loads(body)
     if not isinstance(payload, list):
         raise Exception(
@@ -79,7 +78,7 @@ def _check_ruleset_response(
         detail = body
     match status:
         case 404:
-            raise Exception(not_found_msg)
+            raise Exception(f"{not_found_msg}: {detail}")
         case 422 if has_422:
             raise Exception(f"Validation failed {error_context}: {detail}")
         case 500:

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -539,7 +539,6 @@ def reconcile_rulesets(
             update_ruleset(self, ruleset_id, ruleset)
         else:
             print(f"Creating GitHub ruleset '{name}'")
-            print(json.dumps(ruleset, indent=2))
             add_ruleset(self, ruleset)
 
     removed_names = previously_managed_names - desired_names

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -20,6 +20,8 @@
 import json
 from typing import Any
 
+from github import UnknownObjectException
+
 from . import directive, ASFGitHubFeature
 
 COPILOT_RULESET_NAME = "Copilot Code Review"
@@ -169,12 +171,11 @@ def _resolve_integration_id(
         if not resolve_references:
             return -1
         if candidate not in app_cache:
-            response = self.ghrepo._requester.requestJson("GET", f"/apps/{candidate}")
-            payload = _extract_json_payload(response)
-            app_id = payload.get("id") if isinstance(payload, dict) else None
-            if not isinstance(app_id, int):
-                raise Exception(f"Unable to resolve app_slug '{candidate}' to integration_id")
-            app_cache[candidate] = app_id
+            try:
+                app = self.gh.get_app(candidate)
+                app_cache[candidate] = app.id
+            except UnknownObjectException as exc:
+                raise Exception(f"Unable to resolve app_slug '{candidate}' to integration_id") from exc
         return app_cache[candidate]
 
     raise Exception("required_status_checks.app_slug must be a string or integer")

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -61,7 +61,9 @@ def list_rulesets(self: ASFGitHubFeature) -> list[dict[str, Any]]:
             raise Exception(f"Unexpected response while listing rulesets: HTTP {status}")
     payload = json.loads(body)
     if not isinstance(payload, list):
-        raise Exception(f"Unexpected response format while listing rulesets: expected a list, got {type(payload).__name__}")
+        raise Exception(
+            f"Unexpected response format while listing rulesets: expected a list, got {type(payload).__name__}"
+        )
     return [ruleset for ruleset in payload if isinstance(ruleset, dict)]
 
 
@@ -90,7 +92,9 @@ def add_ruleset(self: ASFGitHubFeature, ruleset: dict[str, Any]) -> None:
     name = ruleset["name"]
     status, _headers, body = self.ghrepo._requester.requestJson("POST", _rulesets_endpoint(self), input=ruleset)
     _check_ruleset_response(
-        status, 201, body=body,
+        status,
+        201,
+        body=body,
         not_found_msg=f"Repository '{self.repository.org_id}/{self.repository.name}' not found or not accessible",
         error_context=f"while creating ruleset '{name}'",
     )
@@ -102,18 +106,20 @@ def update_ruleset(self: ASFGitHubFeature, ruleset_id: int, ruleset: dict[str, A
         "PUT", f"{_rulesets_endpoint(self)}/{ruleset_id}", input=ruleset
     )
     _check_ruleset_response(
-        status, 200, body=body,
+        status,
+        200,
+        body=body,
         not_found_msg=f"Ruleset '{name}' ({ruleset_id}) not found",
         error_context=f"while updating ruleset '{name}' ({ruleset_id})",
     )
 
 
 def delete_ruleset(self: ASFGitHubFeature, ruleset_id: int, name: str) -> None:
-    status, _headers, body = self.ghrepo._requester.requestJson(
-        "DELETE", f"{_rulesets_endpoint(self)}/{ruleset_id}"
-    )
+    status, _headers, body = self.ghrepo._requester.requestJson("DELETE", f"{_rulesets_endpoint(self)}/{ruleset_id}")
     _check_ruleset_response(
-        status, 204, body=body,
+        status,
+        204,
+        body=body,
         not_found_msg=f"Ruleset '{name}' ({ruleset_id}) not found",
         error_context=f"while deleting ruleset '{name}' ({ruleset_id})",
         has_422=False,

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -48,29 +48,17 @@ def _rulesets_endpoint(self: ASFGitHubFeature) -> str:
     return f"/repos/{self.repository.org_id}/{self.repository.name}/rulesets"
 
 
-def _extract_json_payload(response: Any) -> Any:
-    if isinstance(response, (dict, list)):
-        return response
-
-    if isinstance(response, tuple):
-        for item in reversed(response):
-            if isinstance(item, (dict, list)):
-                return item
-        for item in reversed(response):
-            if isinstance(item, str):
-                try:
-                    return json.loads(item)
-                except json.JSONDecodeError:
-                    continue
-
-    return []
-
-
 def list_rulesets(self: ASFGitHubFeature) -> list[dict[str, Any]]:
-    response = self.ghrepo._requester.requestJson("GET", _rulesets_endpoint(self))
-    payload = _extract_json_payload(response)
+    status, _headers, body = self.ghrepo._requester.requestJson("GET", _rulesets_endpoint(self))
+    if status == 404:
+        raise Exception(f"Repository '{self.repository.org_id}/{self.repository.name}' not found or not accessible")
+    if status == 500:
+        raise Exception("GitHub server error while listing rulesets")
+    if status != 200:
+        raise Exception(f"Unexpected response while listing rulesets: HTTP {status}")
+    payload = json.loads(body)
     if not isinstance(payload, list):
-        return []
+        raise Exception(f"Unexpected response format while listing rulesets: expected a list, got {type(payload).__name__}")
     return [ruleset for ruleset in payload if isinstance(ruleset, dict)]
 
 

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -153,7 +153,10 @@ def _resolve_team_id(self: ASFGitHubFeature, team: Any, *, resolve_references: b
     if not resolve_references:
         return -1
     if team not in team_cache:
-        team_cache[team] = self.gh.get_organization(self.repository.org_id).get_team_by_slug(team).id
+        try:
+            team_cache[team] = self.gh.get_organization(self.repository.org_id).get_team_by_slug(team).id
+        except UnknownObjectException as exc:
+            raise Exception(f"Unable to resolve bypass_team '{team}' to team ID") from exc
     return team_cache[team]
 
 

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -230,8 +230,18 @@ def _resolve_integration_id(
     raise Exception("required_status_checks.app_slug must be a string or integer")
 
 
+def _to_ref(pattern: str, target: str) -> str:
+    """Prefix a bare name with refs/heads/ or refs/tags/; leave refs/ and ~ patterns untouched."""
+    if pattern.startswith("refs/") or pattern.startswith("~"):
+        return pattern
+    prefix = "refs/heads/" if target == "branch" else "refs/tags/"
+    return f"{prefix}{pattern}"
+
+
 def _build_ref_name_condition(ruleset: dict[str, Any], target: str) -> dict[str, list[str]]:
-    ref_config = ruleset.get("branches", ruleset.get("refs"))
+    use_branches = "branches" in ruleset
+    ref_config = ruleset.get("branches") if use_branches else ruleset.get("refs")
+
     if ref_config is None:
         if target == "branch":
             return {"include": ["~DEFAULT_BRANCH"], "exclude": []}
@@ -247,9 +257,16 @@ def _build_ref_name_condition(ruleset: dict[str, Any], target: str) -> dict[str,
 
     exclude = ref_config.get("excludes", [])
 
+    include = _expect_string_list(include, "ruleset branches.includes")
+    exclude = _expect_string_list(exclude, "ruleset branches.excludes")
+
+    if use_branches:
+        include = [_to_ref(p, target) for p in include]
+        exclude = [_to_ref(p, target) for p in exclude]
+
     return {
-        "include": _expect_string_list(include, "ruleset branches.includes"),
-        "exclude": _expect_string_list(exclude, "ruleset branches.excludes"),
+        "include": include,
+        "exclude": exclude,
     }
 
 

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -50,16 +50,74 @@ def _rulesets_endpoint(self: ASFGitHubFeature) -> str:
 
 def list_rulesets(self: ASFGitHubFeature) -> list[dict[str, Any]]:
     status, _headers, body = self.ghrepo._requester.requestJson("GET", _rulesets_endpoint(self))
-    if status == 404:
-        raise Exception(f"Repository '{self.repository.org_id}/{self.repository.name}' not found or not accessible")
-    if status == 500:
-        raise Exception("GitHub server error while listing rulesets")
-    if status != 200:
-        raise Exception(f"Unexpected response while listing rulesets: HTTP {status}")
+    match status:
+        case 200:
+            pass
+        case 404:
+            raise Exception(f"Repository '{self.repository.org_id}/{self.repository.name}' not found or not accessible")
+        case 500:
+            raise Exception("GitHub server error while listing rulesets")
+        case _:
+            raise Exception(f"Unexpected response while listing rulesets: HTTP {status}")
     payload = json.loads(body)
     if not isinstance(payload, list):
         raise Exception(f"Unexpected response format while listing rulesets: expected a list, got {type(payload).__name__}")
     return [ruleset for ruleset in payload if isinstance(ruleset, dict)]
+
+
+def _check_ruleset_response(
+    status: int, success_code: int, not_found_msg: str, error_context: str, body: str, *, has_422: bool = True
+) -> None:
+    if status == success_code:
+        return
+    try:
+        parsed = json.loads(body)
+        detail = str(parsed.get("errors") or parsed.get("message") or body)
+    except (json.JSONDecodeError, AttributeError):
+        detail = body
+    match status:
+        case 404:
+            raise Exception(not_found_msg)
+        case 422 if has_422:
+            raise Exception(f"Validation failed {error_context}: {detail}")
+        case 500:
+            raise Exception(f"GitHub server error {error_context}: {detail}")
+        case _:
+            raise Exception(f"Unexpected response {error_context}: HTTP {status}: {detail}")
+
+
+def add_ruleset(self: ASFGitHubFeature, ruleset: dict[str, Any]) -> None:
+    name = ruleset["name"]
+    status, _headers, body = self.ghrepo._requester.requestJson("POST", _rulesets_endpoint(self), input=ruleset)
+    _check_ruleset_response(
+        status, 201, body=body,
+        not_found_msg=f"Repository '{self.repository.org_id}/{self.repository.name}' not found or not accessible",
+        error_context=f"while creating ruleset '{name}'",
+    )
+
+
+def update_ruleset(self: ASFGitHubFeature, ruleset_id: int, ruleset: dict[str, Any]) -> None:
+    name = ruleset["name"]
+    status, _headers, body = self.ghrepo._requester.requestJson(
+        "PUT", f"{_rulesets_endpoint(self)}/{ruleset_id}", input=ruleset
+    )
+    _check_ruleset_response(
+        status, 200, body=body,
+        not_found_msg=f"Ruleset '{name}' ({ruleset_id}) not found",
+        error_context=f"while updating ruleset '{name}' ({ruleset_id})",
+    )
+
+
+def delete_ruleset(self: ASFGitHubFeature, ruleset_id: int, name: str) -> None:
+    status, _headers, body = self.ghrepo._requester.requestJson(
+        "DELETE", f"{_rulesets_endpoint(self)}/{ruleset_id}"
+    )
+    _check_ruleset_response(
+        status, 204, body=body,
+        not_found_msg=f"Ruleset '{name}' ({ruleset_id}) not found",
+        error_context=f"while deleting ruleset '{name}' ({ruleset_id})",
+        has_422=False,
+    )
 
 
 def get_ruleset_names(rulesets: Any) -> set[str]:
@@ -440,7 +498,6 @@ def reconcile_rulesets(
     desired_rulesets: list[dict[str, Any]],
     previously_managed_names: set[str],
 ) -> None:
-    endpoint = _rulesets_endpoint(self)
     existing_by_name: dict[str, dict[str, Any]] = {}
 
     existing_rulesets = list_rulesets(self)
@@ -462,10 +519,11 @@ def reconcile_rulesets(
             if ruleset_id is None:
                 raise Exception(f"Found ruleset '{name}' without an id")
             print(f"Updating GitHub ruleset '{name}' ({ruleset_id})")
-            self.ghrepo._requester.requestJson("PUT", f"{endpoint}/{ruleset_id}", input=ruleset)
+            update_ruleset(self, ruleset_id, ruleset)
         else:
             print(f"Creating GitHub ruleset '{name}'")
-            self.ghrepo._requester.requestJson("POST", endpoint, input=ruleset)
+            print(json.dumps(ruleset, indent=2))
+            add_ruleset(self, ruleset)
 
     removed_names = previously_managed_names - desired_names
     for name in sorted(removed_names):
@@ -476,7 +534,7 @@ def reconcile_rulesets(
         if ruleset_id is None:
             raise Exception(f"Found ruleset '{name}' without an id")
         print(f"Deleting GitHub ruleset '{name}' ({ruleset_id})")
-        self.ghrepo._requester.requestJson("DELETE", f"{endpoint}/{ruleset_id}")
+        delete_ruleset(self, ruleset_id, name)
 
 
 @directive

--- a/tests/github_copilot_code_review.py
+++ b/tests/github_copilot_code_review.py
@@ -17,6 +17,7 @@
 
 """Unit tests for .asf.yaml GitHub Copilot code review feature."""
 
+import json
 from types import SimpleNamespace
 from typing import Any
 
@@ -64,9 +65,15 @@ class FakeRequester:
 
     def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
         self.calls.append({"method": method, "url": url, "input": input})
-        if method == "GET":
-            return 200, {}, self.rulesets
-        return 200, {}, {}
+        match method:
+            case "GET":
+                return 200, {}, json.dumps(self.rulesets)
+            case "POST":
+                return 201, {}, "{}"
+            case "PUT":
+                return 200, {}, "{}"
+            case _:
+                return 204, {}, "{}"
 
 
 class FakeFeature:

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -17,6 +17,7 @@
 
 """Unit tests for .asf.yaml GitHub rulesets feature."""
 
+import json
 from types import SimpleNamespace
 from typing import Any
 
@@ -125,15 +126,16 @@ def _build_ruleset_payload(name: str) -> dict[str, Any]:
 
 
 class FakeRequester:
-    def __init__(self, rulesets: list[dict[str, Any]] | None = None):
+    def __init__(self, rulesets: list[dict[str, Any]] | None = None, *, list_status: int = 200):
         self.rulesets = rulesets or []
+        self.list_status = list_status
         self.calls: list[dict[str, Any]] = []
 
     def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
         self.calls.append({"method": method, "url": url, "input": input})
         if method == "GET":
-            return 200, {}, self.rulesets
-        return 200, {}, {}
+            return self.list_status, {}, json.dumps(self.rulesets)
+        return 200, {}, "{}"
 
 
 class FakeFeature:
@@ -551,6 +553,39 @@ def test_rulesets_convenience_conversation_resolution_false_does_not_add_pull_re
     rule_types = [rule["type"] for rule in payload["rules"]]
     assert "required_signatures" in rule_types
     assert "pull_request" not in rule_types
+
+
+@pytest.mark.parametrize(
+    ("status", "match"),
+    [
+        (404, "not found or not accessible"),
+        (500, "GitHub server error"),
+        (403, "Unexpected response while listing rulesets: HTTP 403"),
+    ],
+)
+def test_rulesets_list_error_status_raises(status: int, match: str):
+    requester = FakeRequester(list_status=status)
+    feature = FakeFeature(
+        yaml={"rulesets": [_build_ruleset_payload("Default branch checks")]},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match=match):
+        configure_rulesets(feature)
+
+
+def test_rulesets_list_unexpected_payload_raises():
+    requester = FakeRequester()
+    requester.rulesets = {}  # type: ignore[assignment]  — force a non-list body
+    feature = FakeFeature(
+        yaml={"rulesets": [_build_ruleset_payload("Default branch checks")]},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match="expected a list, got dict"):
+        configure_rulesets(feature)
 
 
 def test_rulesets_update_existing_ruleset():

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -251,7 +251,7 @@ def test_rulesets_convenience_syntax_creates_ruleset():
     assert payload["name"] == "Branch Protection"
     assert payload["target"] == "branch"
     assert payload["enforcement"] == "active"
-    assert payload["conditions"]["ref_name"]["include"] == ["main"]
+    assert payload["conditions"]["ref_name"]["include"] == ["refs/heads/main"]
     assert payload["conditions"]["ref_name"]["exclude"] == []
 
     rule_types = [rule["type"] for rule in payload["rules"]]
@@ -366,6 +366,37 @@ def test_rulesets_convenience_unknown_app_slug_raises():
         configure_rulesets(feature)
 
     assert isinstance(exc_info.value.__cause__, UnknownObjectException)
+
+
+@pytest.mark.parametrize(
+    ("ruleset_type", "key", "pattern", "expected"),
+    [
+        # branches + branch target: bare name gets refs/heads/ prefix
+        ("branch", "branches", "main", "refs/heads/main"),
+        ("branch", "branches", "release/*", "refs/heads/release/*"),
+        # branches + tag target: bare name gets refs/tags/ prefix
+        ("tag", "branches", "rel/*", "refs/tags/rel/*"),
+        ("tag", "branches", "v*.*.*", "refs/tags/v*.*.*"),
+        # already-absolute and tilde patterns are left untouched regardless of target
+        ("branch", "branches", "refs/heads/main", "refs/heads/main"),
+        ("branch", "branches", "~DEFAULT_BRANCH", "~DEFAULT_BRANCH"),
+        ("tag", "branches", "refs/tags/v1.*", "refs/tags/v1.*"),
+        # refs: always passed through as-is
+        ("branch", "refs", "refs/heads/main", "refs/heads/main"),
+        ("tag", "refs", "refs/tags/rel/*", "refs/tags/rel/*"),
+        ("branch", "refs", "main", "main"),
+    ],
+)
+def test_rulesets_ref_name_condition_prefixing(ruleset_type: str, key: str, pattern: str, expected: str):
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"rulesets": [{"name": "R", "type": ruleset_type, key: {"includes": [pattern]}}]},
+        previous_yaml={},
+        requester=requester,
+    )
+    configure_rulesets(feature)
+    payload = requester.calls[1]["input"]
+    assert payload["conditions"]["ref_name"]["include"] == [expected]
 
 
 def test_rulesets_convenience_tag_restrict_force_push_rule():

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -126,16 +126,34 @@ def _build_ruleset_payload(name: str) -> dict[str, Any]:
 
 
 class FakeRequester:
-    def __init__(self, rulesets: list[dict[str, Any]] | None = None, *, list_status: int = 200):
+    def __init__(
+        self,
+        rulesets: list[dict[str, Any]] | None = None,
+        *,
+        list_status: int = 200,
+        post_status: int = 201,
+        put_status: int = 200,
+        delete_status: int = 204,
+    ):
         self.rulesets = rulesets or []
         self.list_status = list_status
+        self.post_status = post_status
+        self.put_status = put_status
+        self.delete_status = delete_status
         self.calls: list[dict[str, Any]] = []
 
     def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
         self.calls.append({"method": method, "url": url, "input": input})
-        if method == "GET":
-            return self.list_status, {}, json.dumps(self.rulesets)
-        return 200, {}, "{}"
+        error_body = json.dumps({"message": "Validation Failed", "errors": [{"field": "rules", "code": "invalid"}]})
+        match method:
+            case "GET":
+                return self.list_status, {}, json.dumps(self.rulesets)
+            case "POST":
+                return self.post_status, {}, error_body
+            case "PUT":
+                return self.put_status, {}, error_body
+            case _:
+                return self.delete_status, {}, error_body
 
 
 class FakeFeature:
@@ -585,6 +603,70 @@ def test_rulesets_list_unexpected_payload_raises():
     )
 
     with pytest.raises(Exception, match="expected a list, got dict"):
+        configure_rulesets(feature)
+
+
+@pytest.mark.parametrize(
+    ("post_status", "match"),
+    [
+        (404, "not found or not accessible"),
+        (422, "Validation failed while creating ruleset.*rules.*invalid"),
+        (500, "GitHub server error while creating ruleset"),
+        (503, "Unexpected response while creating ruleset 'Default branch checks': HTTP 503"),
+    ],
+)
+def test_rulesets_add_error_status_raises(post_status: int, match: str):
+    requester = FakeRequester(post_status=post_status)
+    feature = FakeFeature(
+        yaml={"rulesets": [_build_ruleset_payload("Default branch checks")]},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match=match):
+        configure_rulesets(feature)
+
+
+@pytest.mark.parametrize(
+    ("put_status", "match"),
+    [
+        (404, "Ruleset 'Default branch checks' \\(22\\) not found"),
+        (422, "Validation failed while updating ruleset 'Default branch checks' \\(22\\).*rules.*invalid"),
+        (500, "GitHub server error while updating ruleset 'Default branch checks' \\(22\\)"),
+        (503, "Unexpected response while updating ruleset 'Default branch checks' \\(22\\): HTTP 503"),
+    ],
+)
+def test_rulesets_update_error_status_raises(put_status: int, match: str):
+    payload = _build_ruleset_payload("Default branch checks")
+    requester = FakeRequester(rulesets=[{"id": 22, "name": payload["name"]}], put_status=put_status)
+    feature = FakeFeature(
+        yaml={"rulesets": [payload]},
+        previous_yaml={"rulesets": [payload]},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match=match):
+        configure_rulesets(feature)
+
+
+@pytest.mark.parametrize(
+    ("delete_status", "match"),
+    [
+        (404, "Ruleset 'Default branch checks' \\(31\\) not found"),
+        (500, "GitHub server error while deleting ruleset 'Default branch checks' \\(31\\)"),
+        (503, "Unexpected response while deleting ruleset 'Default branch checks' \\(31\\): HTTP 503"),
+    ],
+)
+def test_rulesets_delete_error_status_raises(delete_status: int, match: str):
+    existing = [{"id": 31, "name": "Default branch checks"}]
+    requester = FakeRequester(rulesets=existing, delete_status=delete_status)
+    feature = FakeFeature(
+        yaml={},
+        previous_yaml={"rulesets": [_build_ruleset_payload("Default branch checks")]},
+        requester=requester,
+    )
+
+    with pytest.raises(Exception, match=match):
         configure_rulesets(feature)
 
 

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -247,11 +247,19 @@ def test_rulesets_convenience_syntax_creates_ruleset():
 
 
 def test_rulesets_convenience_resolves_bypass_team_and_app_slug():
+    def get_team_by_slug(slug: str):
+        if slug not in {"infra"}:
+            raise UnknownObjectException(404, {"message": "Not Found"}, {})
+        return SimpleNamespace(id={"infra": 202}[slug])
+
+    def get_app(slug: str):
+        if slug not in {"jenkins"}:
+            raise UnknownObjectException(404, {"message": "Not Found"}, {})
+        return SimpleNamespace(id={"jenkins": 303}[slug])
+
     fake_gh = SimpleNamespace(
-        get_organization=lambda _org: SimpleNamespace(
-            get_team_by_slug=lambda slug: SimpleNamespace(id={"infra": 202}[slug])
-        ),
-        get_app=lambda slug: SimpleNamespace(id={"jenkins": 303}[slug]),
+        get_organization=lambda _org: SimpleNamespace(get_team_by_slug=get_team_by_slug),
+        get_app=get_app,
     )
     requester = FakeRequester()
     feature = FakeFeature(
@@ -282,6 +290,35 @@ def test_rulesets_convenience_resolves_bypass_team_and_app_slug():
     assert status_rule["parameters"]["required_status_checks"] == [
         {"context": "gh-infra/jenkins", "integration_id": 303}
     ]
+
+
+def test_rulesets_convenience_unknown_bypass_team_raises():
+    def raise_unknown(_slug: str):
+        raise UnknownObjectException(404, {"message": "Not Found"}, {})
+
+    fake_gh = SimpleNamespace(
+        get_organization=lambda _org: SimpleNamespace(get_team_by_slug=raise_unknown),
+    )
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "bypass_teams": ["unknown-team"],
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+        gh=fake_gh,
+    )
+
+    with pytest.raises(Exception, match="Unable to resolve bypass_team 'unknown-team' to team ID") as exc_info:
+        configure_rulesets(feature)
+
+    assert isinstance(exc_info.value.__cause__, UnknownObjectException)
 
 
 def test_rulesets_convenience_unknown_app_slug_raises():

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -23,6 +23,7 @@ from typing import Any
 import asfyaml.asfyaml
 import asfyaml.dataobjects
 import pytest
+from github import UnknownObjectException
 from asfyaml.feature.github.rulesets import COPILOT_RULESET_NAME, rulesets as configure_rulesets
 from helpers import YamlTest
 
@@ -124,19 +125,12 @@ def _build_ruleset_payload(name: str) -> dict[str, Any]:
 
 
 class FakeRequester:
-    def __init__(self, rulesets: list[dict[str, Any]] | None = None, apps: dict[str, int] | None = None):
+    def __init__(self, rulesets: list[dict[str, Any]] | None = None):
         self.rulesets = rulesets or []
-        self.apps = apps or {}
         self.calls: list[dict[str, Any]] = []
 
     def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
         self.calls.append({"method": method, "url": url, "input": input})
-        if method == "GET" and url.startswith("/apps/"):
-            app_slug = url.rsplit("/", 1)[-1]
-            app_id = self.apps.get(app_slug)
-            if app_id is None:
-                return 404, {}, {}
-            return 200, {}, {"id": app_id}
         if method == "GET":
             return 200, {}, self.rulesets
         return 200, {}, {}
@@ -257,8 +251,9 @@ def test_rulesets_convenience_resolves_bypass_team_and_app_slug():
         get_organization=lambda _org: SimpleNamespace(
             get_team_by_slug=lambda slug: SimpleNamespace(id={"infra": 202}[slug])
         ),
+        get_app=lambda slug: SimpleNamespace(id={"jenkins": 303}[slug]),
     )
-    requester = FakeRequester(apps={"jenkins": 303})
+    requester = FakeRequester()
     feature = FakeFeature(
         yaml={
             "rulesets": [
@@ -287,6 +282,33 @@ def test_rulesets_convenience_resolves_bypass_team_and_app_slug():
     assert status_rule["parameters"]["required_status_checks"] == [
         {"context": "gh-infra/jenkins", "integration_id": 303}
     ]
+
+
+def test_rulesets_convenience_unknown_app_slug_raises():
+    def raise_unknown(_slug: str):
+        raise UnknownObjectException(404, {"message": "Not Found"}, {})
+
+    fake_gh = SimpleNamespace(get_app=raise_unknown)
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "required_status_checks": [{"name": "gh-infra/jenkins", "app_slug": "unknown-app"}],
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+        gh=fake_gh,
+    )
+
+    with pytest.raises(Exception, match="Unable to resolve app_slug 'unknown-app' to integration_id") as exc_info:
+        configure_rulesets(feature)
+
+    assert isinstance(exc_info.value.__cause__, UnknownObjectException)
 
 
 def test_rulesets_convenience_tag_restrict_force_push_rule():

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -149,11 +149,13 @@ class FakeRequester:
             case "GET":
                 return self.list_status, {}, json.dumps(self.rulesets)
             case "POST":
-                return self.post_status, {}, error_body
+                return self.post_status, {}, json.dumps({**(input or {}), "id": 999}) if self.post_status == 201 else error_body
             case "PUT":
-                return self.put_status, {}, error_body
+                return self.put_status, {}, json.dumps(input or {}) if self.put_status == 200 else error_body
+            case "DELETE":
+                return self.delete_status, {}, "" if self.delete_status == 204 else error_body
             case _:
-                return self.delete_status, {}, error_body
+                raise ValueError(f"FakeRequester: unexpected HTTP method '{method}'")
 
 
 class FakeFeature:


### PR DESCRIPTION
This PR hardens the rulesets implementation introduced in #89, focusing on correctness and error reporting:

- **App slug resolution**: the previous implementation called the REST API directly and parsed the wrong field from the response, so app slug resolution always silently failed. Switched to `Github.get_app()` for correct resolution.
- **Team slug resolution**: unresolvable bypass team slugs now raise a clear error with exception chaining instead of a bare `UnknownObjectException`.
- **REST API error handling**: all direct REST API calls are now wrapped in dedicated helpers (`list_rulesets`, `add_ruleset`, `update_ruleset`, `delete_ruleset`) that check the HTTP status and raise descriptive exceptions.
- **Ref pattern prefixing**: when using the convenience `branches` key, bare patterns are automatically prefixed with `refs/heads/` (branch rulesets) or `refs/tags/` (tag rulesets), so users don't need to use the internal ref format.