### PR TITLE
GH: Wire prevent_self_review for deployment environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,7 @@ required_reviewers:
   - id: <string> | <int>
     type: 'User' | 'Team'
 wait_timer: <int>
+prevent_self_review: <bool>
 deployment_branch_policy:
   protected_branches: <bool>
   policies:
@@ -945,6 +946,7 @@ deployment_branch_policy:
 
 - `required_reviewers`: A list of reviewers who must approve the deployment. (The `id` is the GitHub user ID or username / team slug.)
 - `wait_timer`: To delay a job for a specific number of minutes after the job is initially triggered.
+- `prevent_self_review`: If set to `true`, the user that triggered the deployment cannot also approve it as a `required_reviewer`.
 - `deployment_branch_policy`: A dictionary of branch policy settings.
 - `protected_branches`: If set to `true`, the deployment branch policy will be set up to allow deploying from all protected branches.
 - `policies`: A list of branch / tag policies to apply for this environment. Only matching branches / tags can deploy to the environment.
@@ -958,6 +960,7 @@ If you do not explicitly specify values, the system uses these values by default
 ```yaml
 required_reviewers: []
 wait_timer: 15
+prevent_self_review: true
 deployment_branch_policy: ~
 ```
 

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -169,8 +169,7 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
                                 }
                             )
                         ),
-                        # not supported yet by PyGithub
-                        # strictyaml.Optional("prevent_self_review"): strictyaml.Bool(),
+                        strictyaml.Optional("prevent_self_review"): strictyaml.Bool(),
                         strictyaml.Optional("wait_timer"): strictyaml.Int(),
                         strictyaml.Optional("deployment_branch_policy"): strictyaml.Map(
                             {

--- a/asfyaml/feature/github/deployment_environments.py
+++ b/asfyaml/feature/github/deployment_environments.py
@@ -88,8 +88,7 @@ def _create_or_update_deployment_environment(self: ASFGitHubFeature, env_name, e
     required_reviewers = env_config.get("required_reviewers", [])
     required_reviewers_with_id = [get_reviewer(reviewer) for reviewer in required_reviewers]
 
-    # prevent_self_review is not supported by pygithub yet, https://github.com/PyGithub/PyGithub/pull/3246 is open
-    # prevent_self_review = env_config.get("prevent_self_review", True)
+    prevent_self_review = env_config.get("prevent_self_review", True)
 
     if "deployment_branch_policy" in env_config:
         deployment_branch_policy = env_config.get("deployment_branch_policy")
@@ -107,6 +106,7 @@ def _create_or_update_deployment_environment(self: ASFGitHubFeature, env_name, e
     print(f"Updates to deployment environment {env_name}")
     print(f"  - Set required_reviewers to {[r.id for r in required_reviewers_with_id]}")
     print(f"  - Set wait_timer to {wait_timer}")
+    print(f"  - Set prevent_self_review to {prevent_self_review}")
     if deployment_branch_policy is None:
         print("  - Set deployment branch policy = None")
     else:
@@ -121,6 +121,7 @@ def _create_or_update_deployment_environment(self: ASFGitHubFeature, env_name, e
             environment_name=env_name,
             wait_timer=wait_timer,
             reviewers=required_reviewers_with_id,
+            prevent_self_review=prevent_self_review,
             deployment_branch_policy=deployment_branch_policy,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pyyaml = "*"
 strictyaml = "*"
 easydict = "*"
 asfpy = "*"
-PyGithub = "^2.5.0"
+PyGithub = "^2.7.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=8.0"

--- a/tests/github_deployment_environments.py
+++ b/tests/github_deployment_environments.py
@@ -70,6 +70,33 @@ github:
 """,
 )
 
+valid_prevent_self_review = YamlTest(
+    None,
+    None,
+    """
+github:
+    environments:
+        test-pypi:
+          required_reviewers:
+            - id: 1234
+          wait_timer: 60
+          prevent_self_review: false
+""",
+)
+
+invalid_prevent_self_review = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "when expecting a boolean",
+    """
+github:
+    environments:
+        test-pypi:
+          required_reviewers:
+            - id: 1234
+          prevent_self_review: 123
+""",
+)
+
 
 def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
     print("[github] Testing deployment environments")
@@ -77,7 +104,9 @@ def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
     tests_to_run = (
         valid_github_deployment_environments,
         invalid_wait_timer,
-        invalid_deployment_branch_policy
+        invalid_deployment_branch_policy,
+        valid_prevent_self_review,
+        invalid_prevent_self_review,
     )
 
     for test in tests_to_run:


### PR DESCRIPTION
## Summary

- PyGithub [PR #3246](https://github.com/PyGithub/PyGithub/pull/3246) (merged 2025-07-30, released in PyGithub 2.7.0) added `prevent_self_review` to `Repository.create_environment`. The asfyaml stub for this option was waiting on it. This PR wires it up.
- Adds `prevent_self_review: <bool>` under each environment in `.asf.yaml`. When `true`, a user who triggers a deployment cannot approve it themselves as a required reviewer.
- **Default is `true` — this is now the default behaviour, as intended.** Matches the secure-by-default posture in the original commented-out code (`# prevent_self_review = env_config.get("prevent_self_review", True)`) that was waiting on PyGithub. Note: existing environments without the key set will flip from GitHub's default of `false` to `true` on the next apply. Projects that need self-approval (e.g. solo-maintained pipelines) can opt out by setting `prevent_self_review: false`.
- Bumps PyGithub floor from `^2.5.0` to `^2.7.0`.

## Test plan

- [x] `pytest tests/github_deployment_environments.py` — adds a valid case (`prevent_self_review: false`) and an invalid case (non-bool rejected by strictyaml schema).
- [x] Full test suite passes (44/44).
- [ ] Apply on a test repo and verify the GitHub Environments UI reflects `Prevent self-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)