### PR TITLE
document ruleset required PR param

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ Notes:
 - Set `restrict_deletion: false` and/or `restrict_force_push: false` to disable those rules for a convenience entry.
 - `deletion` and `non_fast_forward` are raw rule types under `rules`, not convenience top-level keys.
 - Convenience entries may intentionally resolve to `rules: []` (for example, while staging migration changes).
+- If `required_conversation_resolution` is set, `required_pull_request_reviews` must be present as well.
 
 Validation and reconciliation behavior:
 


### PR DESCRIPTION
I worked with @Humbedooh to figure out this is what was breaking my changes to Fineract's .asf.yaml changes when I migrated from protected_branches to rulesets.

I think there's more to the story here there's probably a better way to wordsmith what I'm saying, but perhaps this will still save someone else some time (if they happen to use _only_ required_conversation_resolution and not required_pull_request_reviews with the old protected_branches style).

See:

* https://github.com/apache/fineract/commit/d63a61761033d1a7b6e4caa935ed675f8c843356
* https://issues.apache.org/jira/browse/FINERACT-2605