### PR TITLE
Fix: prevent_self_review breaks all environment creation via .asf.yaml

### DIFF
--- a/asfyaml/feature/github/deployment_environments.py
+++ b/asfyaml/feature/github/deployment_environments.py
@@ -88,7 +88,7 @@ def _create_or_update_deployment_environment(self: ASFGitHubFeature, env_name, e
     required_reviewers = env_config.get("required_reviewers", [])
     required_reviewers_with_id = [get_reviewer(reviewer) for reviewer in required_reviewers]
 
-    prevent_self_review = env_config.get("prevent_self_review", True)
+    prevent_self_review = env_config.get("prevent_self_review", None)
 
     if "deployment_branch_policy" in env_config:
         deployment_branch_policy = env_config.get("deployment_branch_policy")
@@ -106,7 +106,7 @@ def _create_or_update_deployment_environment(self: ASFGitHubFeature, env_name, e
     print(f"Updates to deployment environment {env_name}")
     print(f"  - Set required_reviewers to {[r.id for r in required_reviewers_with_id]}")
     print(f"  - Set wait_timer to {wait_timer}")
-    print(f"  - Set prevent_self_review to {prevent_self_review}")
+    print(f"  - Set prevent_self_review to {prevent_self_review if prevent_self_review is not None else '(not set)'}")
     if deployment_branch_policy is None:
         print("  - Set deployment branch policy = None")
     else:
@@ -117,13 +117,22 @@ def _create_or_update_deployment_environment(self: ASFGitHubFeature, env_name, e
         )
 
     if not self.noop("environment"):
-        self.ghrepo.create_environment(
+        kwargs = dict(
             environment_name=env_name,
             wait_timer=wait_timer,
             reviewers=required_reviewers_with_id,
-            prevent_self_review=prevent_self_review,
             deployment_branch_policy=deployment_branch_policy,
         )
+        if prevent_self_review is not None:
+            kwargs["prevent_self_review"] = prevent_self_review
+        try:
+            self.ghrepo.create_environment(**kwargs)
+        except TypeError as e:
+            if "prevent_self_review" in str(e):
+                kwargs.pop("prevent_self_review", None)
+                self.ghrepo.create_environment(**kwargs)
+            else:
+                raise
 
         if deployment_branch_policy is not None and deployment_branch_policy.custom_branch_policies is True:
             _create_or_update_deployment_branch_policy(self, env_name, policies)


### PR DESCRIPTION
Gotten this email message on two separate repos when setting up Trusted Publishing for PyPi and merging a new version of `.asf.yaml` setting up an environment `pypi`, first on `apache/tooling-asfswhid` and just now on `apache/mahout`:

```
mahout.git: Error while running github feature from main:.asf.yaml
[Mahout/dev]
Apache Infrastructure
12:06 AM (26 minutes ago)
to jiekaichang, commits
An error occurred while processing the github feature in .asf.yaml:

Repository.create_environment() got an unexpected keyword argument 'prevent_self_review'

---
With regards, ASF Infra.
For further information, please see the .asf.yaml documentation at:
https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
```

create_environment() always passes prevent_self_review=True (the default) to PyGithub's Repository.create_environment(), but the installed PyGithub version does not support that parameter, causing a TypeError that prevents any deployment environment from being created.

This patch:
- Defaults prevent_self_review to None instead of True (only pass when explicitly set in .asf.yaml)
- Falls back gracefully if PyGithub raises TypeError on the parameter, retrying without it