### PR TITLE
Add new fields from ATR into schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ project:
     download_page: https://github.com/apache/tooling-trusted-releases
     bug_database: https://github.com/apache/tooling-trusted-releases/issues
     mailing_lists: https://tooling.apache.org/lists.html
+    security_contact: security@apache.org
+    threat_model_link: https://tooling.apache.org/security/threat-model
+    threat_model_src_link: https://github.com/apache/tooling-trusted-releases/blob/main/THREATS.md
     repositories:
       - git+ssh://git@github.com:apache/tooling-trusted-releases.git
     standards:
@@ -140,6 +143,8 @@ project:
   features:
     atr_sync: true
 ~~~
+
+`security_contact`, if set, must be either `security@apache.org` or `security@<committee>.apache.org`. The two threat-model fields are URLs: `threat_model_link` points at the published threat model, and `threat_model_src_link` at its source.
 
 Alternatively, if you already have a DOAP file and want to continue to use it as the main source of project data, you can link the DOAP file into ATR like this:
 
@@ -201,6 +206,7 @@ The remaining fields:
 | `source_excludes_rat` | list of globs | Paths excluded from the RAT license check. |
 | `file_tag_mappings` | map of label to globs | Groups release files under named tags. |
 | `release_checklist` | string | Checklist shown to release managers. |
+| `download_path_suffix` | string | Subdirectory the release is published under. A per-release template that may use `{{PROJECT_KEY}}` and `{{VERSION}}`. |
 | `start_vote_subject` / `start_vote_template` | string | Subject and body for the vote-start email. |
 | `vote_comment_template` | string | Template for vote comments. |
 | `finish_vote_template` | string | Template for the vote-result email. |

--- a/asfyaml/feature/project.py
+++ b/asfyaml/feature/project.py
@@ -53,6 +53,11 @@ _METADATA_SCHEMA = strictyaml.Map(
         strictyaml.Optional("download_page"): strictyaml.Str(),
         strictyaml.Optional("bug_database"): strictyaml.Str(),
         strictyaml.Optional("mailing_lists"): strictyaml.Str(),
+        # Security fields. ATR checks the values: the contact must be security@apache.org
+        # or security@<committee>.apache.org, and the two links must be URLs.
+        strictyaml.Optional("security_contact"): strictyaml.Str(),
+        strictyaml.Optional("threat_model_link"): strictyaml.Str(),
+        strictyaml.Optional("threat_model_src_link"): strictyaml.Str(),
         strictyaml.Optional("repositories"): strictyaml.Seq(strictyaml.Str()),
         strictyaml.Optional("standards"): strictyaml.Seq(strictyaml.Str()),
         strictyaml.Optional("categories"): strictyaml.Seq(strictyaml.Str()),
@@ -75,6 +80,9 @@ _POLICY_SCHEMA = strictyaml.Map(
         strictyaml.Optional("announce_release_subject"): strictyaml.Str(),
         strictyaml.Optional("announce_release_template"): strictyaml.Str(),
         strictyaml.Optional("binary_artifact_paths"): strictyaml.Seq(strictyaml.Str()),
+        # Subdirectory the release is published under, as a per-release template that may
+        # use {{PROJECT_KEY}}/{{VERSION}}. ATR checks it resolves to a valid relative path.
+        strictyaml.Optional("download_path_suffix"): strictyaml.Str(),
         strictyaml.Optional("file_tag_mappings"): strictyaml.MapPattern(
             strictyaml.Str(), strictyaml.Seq(strictyaml.Str())
         ),
@@ -128,11 +136,15 @@ class ASFATRFeature(ASFYamlFeature, name="project", env="production", priority=5
                 committee: tooling   # required; repo must be named <committee>-xxx
                 name: Apache Foo
                 homepage: https://foo.apache.org/
+                security_contact: security@apache.org   # or security@<committee>.apache.org
+                threat_model_link: https://foo.apache.org/security/threat-model
+                threat_model_src_link: https://github.com/apache/foo/blob/main/THREATS.md
                 # ...or, instead of the fields above, point at a DOAP file:
                 doap: https://foo.apache.org/doap.rdf
               policy:
                 vote_recipients:
                   to: private@foo.apache.org
+                download_path_suffix: "{{PROJECT_KEY}}/{{VERSION}}"   # subdir releases land under
               features:
                 atr_sync: true       # set false to opt out of syncing
         """

--- a/tests/project_metadata.py
+++ b/tests/project_metadata.py
@@ -123,6 +123,25 @@ project:
 """,
 )
 
+# The security fields and the download path suffix, as added to ATR.
+valid_security_and_download_suffix = YamlTest(
+    None,
+    None,
+    """
+project:
+    metadata:
+        key: tooling
+        committee: tooling
+        name: Apache Tooling
+        homepage: https://github.com/test
+        security_contact: security@apache.org
+        threat_model_link: http://test/
+        threat_model_src_link: http://test/
+    policy:
+        download_path_suffix: tesettest
+""",
+)
+
 # metadata is a required key
 invalid_missing_metadata = YamlTest(
     asfyaml.asfyaml.ASFYAMLException,
@@ -229,6 +248,7 @@ def test_schema_validation(test_repo: asfyaml.dataobjects.Repository):
         valid_metadata_with_policy,
         valid_full_policy,
         valid_metadata_with_doap,
+        valid_security_and_download_suffix,
         invalid_missing_metadata,
         invalid_missing_key,
         invalid_unknown_metadata_key,
@@ -495,6 +515,35 @@ project:
     assert policy["license_check_mode"] == "RAT"
     assert policy["binary_artifact_paths"] == ["dist/*.jar"]
     assert policy["file_tag_mappings"] == {"sources": ["*.tar.gz"]}
+
+
+def test_noop_payload_carries_security_and_download_suffix(atr_repo: asfyaml.dataobjects.Repository, capsys):
+    yaml = """
+project:
+    metadata:
+        key: tooling
+        committee: tooling
+        name: Apache Tooling
+        security_contact: security@apache.org
+        threat_model_link: http://test/
+        threat_model_src_link: http://test/
+    policy:
+        download_path_suffix: tesettest
+"""
+    a = asfyaml.asfyaml.ASFYamlInstance(
+        repo=atr_repo, committer="arm", config_data=yaml, branch=asfyaml.dataobjects.DEFAULT_BRANCH
+    )
+    a.environments_enabled.add("noop")
+    a.no_cache = True
+    a.run_parts()
+
+    out = capsys.readouterr().out
+    payload = json.loads(out[out.index("{") : out.rindex("}") + 1])
+    # Security fields ride along in the project block; the suffix is a policy field.
+    assert payload["project"]["security_contact"] == "security@apache.org"
+    assert payload["project"]["threat_model_link"] == "http://test/"
+    assert payload["project"]["threat_model_src_link"] == "http://test/"
+    assert payload["policy"]["download_path_suffix"] == "tesettest"
 
 
 def test_committee_matching_repo_prefix_is_accepted(atr_repo: asfyaml.dataobjects.Repository, capsys):


### PR DESCRIPTION
Adds the security fields from https://github.com/apache/tooling-trusted-releases/issues/1321 and download path suffix from https://github.com/apache/tooling-trusted-releases/issues/1344 into .asf.yaml 