### PR TITLE
Add GitHub pull request creation cap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ It operates on a per-branch basis, meaning you can have different settings for d
       <li><a href="#depend_alerts">Dependabot alerts and updates</a></li>
       <li><a href="#GHA_build_status">GitHub Actions build status emails</a></li>
       <li><a href="#pages">GitHub Pages</a></li>
-      <li><a href="#pull_requests">Pull Request settings</a></li>
+      <li><a href="#pull_requests">Pull Request settings</a>
+        <ul>
+          <li><a href="#pr_creation_cap">Pull request creation cap</a></li>
+        </ul>
+      </li>
       <li><a href="#copilot_code_review">Copilot code review</a></li>
       <li><a href="#rulesets">Rulesets</a></li>
       <li><a href="#merge">Merge buttons</a></li>
@@ -769,6 +773,7 @@ Projects can enable/disable various settings for PRs:
 - allow [auto-merging](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) of PRs
 - allow [updating](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch) head branches of PRs
 - automatically [delete](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches) head branches after merge
+- cap the number of open PRs a user without write access may have at one time (see [creation cap](#pr_creation_cap) below)
 
 Example:
 
@@ -782,6 +787,33 @@ github:
     # auto-delete head branches after being merged
     del_branch_on_merge: true
 ~~~
+
+<h4 id="pr_creation_cap">Pull request creation cap</h4>
+
+You can limit the number of open pull requests a user **without write access** may have open at one
+time. This is GitHub's [pull request creation cap](https://github.blog/changelog/2026-06-17-limit-open-pull-requests-for-users-without-write-access/)
+interaction limit, and it helps mitigate spam or automated PR floods. Users with write access are not
+affected by the cap.
+
+~~~yaml
+github:
+  pull_requests:
+    creation_cap:
+      # turn the cap on or off
+      enabled: true
+      # maximum number of open PRs a user without write access may have (1-1000)
+      max_open_pull_requests: 5
+~~~
+
+Supported settings:
+
+~~~yaml
+enabled: <boolean>                # required
+max_open_pull_requests: <int>     # optional, 1-1000; if omitted, GitHub's default is used
+~~~
+
+Set `enabled: false` to turn the cap off. Removing the `creation_cap` section also disables a cap that
+was previously managed by `.asf.yaml`.
 
 <h3 id="copilot_code_review">Copilot code review</h3>
 

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -137,6 +137,14 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
                     strictyaml.Optional("del_branch_on_merge"): strictyaml.Bool(),
                     strictyaml.Optional("allow_auto_merge"): strictyaml.Bool(),
                     strictyaml.Optional("allow_update_branch"): strictyaml.Bool(),
+                    # Pull request creation cap: limit the number of open pull requests a user
+                    # without write access may have at one time.
+                    strictyaml.Optional("creation_cap"): strictyaml.Map(
+                        {
+                            "enabled": strictyaml.Bool(),
+                            strictyaml.Optional("max_open_pull_requests"): strictyaml.Int(),
+                        }
+                    ),
                 }
             ),
             # Generic repository rulesets
@@ -266,6 +274,7 @@ from . import (
     features,
     branch_protection,
     pull_requests,
+    pr_creation_cap,
     merge_buttons,
     pages,
     custom_subjects,

--- a/asfyaml/feature/github/pr_creation_cap.py
+++ b/asfyaml/feature/github/pr_creation_cap.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""GitHub pull request creation cap support.
+
+Limits the number of open pull requests a user without write access may have open
+at one time, via the repository interaction-limits API. See
+https://github.com/community/maintainers/discussions/840 and
+https://docs.github.com/rest/interactions/repos#update-pull-request-creation-cap-for-a-repository
+"""
+
+from typing import Any
+
+from . import directive, ASFGitHubFeature
+
+# Bounds enforced by the GitHub API for max_open_pull_requests.
+MIN_OPEN_PULL_REQUESTS = 1
+MAX_OPEN_PULL_REQUESTS = 1000
+
+
+def _creation_cap_url(self: ASFGitHubFeature) -> str:
+    return f"/repos/{self.repository.org_id}/{self.repository.name}/interaction-limits/pulls/creation-cap"
+
+
+@directive
+def pr_creation_cap(self: ASFGitHubFeature):
+    pull_requests = self.yaml.get("pull_requests") or {}
+    creation_cap = pull_requests.get("creation_cap")
+
+    previous_yaml = self.previous_yaml if isinstance(self.previous_yaml, dict) else {}
+    previous_pull_requests = previous_yaml.get("pull_requests") or {}
+    was_previously_configured = "creation_cap" in previous_pull_requests
+
+    if creation_cap:
+        enabled = creation_cap.get("enabled", False)
+        max_open_pull_requests = creation_cap.get("max_open_pull_requests")
+    elif was_previously_configured:
+        # The section was removed; disable the cap that .asf.yaml previously managed.
+        enabled = False
+        max_open_pull_requests = None
+    else:
+        return
+
+    if not enabled and not was_previously_configured:
+        return
+
+    payload: dict[str, Any] = {"enabled": enabled}
+    if enabled and max_open_pull_requests is not None:
+        if not MIN_OPEN_PULL_REQUESTS <= max_open_pull_requests <= MAX_OPEN_PULL_REQUESTS:
+            raise Exception(
+                "github.pull_requests.creation_cap.max_open_pull_requests must be between "
+                f"{MIN_OPEN_PULL_REQUESTS} and {MAX_OPEN_PULL_REQUESTS}, got {max_open_pull_requests}"
+            )
+        payload["max_open_pull_requests"] = max_open_pull_requests
+
+    if enabled:
+        if "max_open_pull_requests" in payload:
+            print(f"Setting pull request creation cap to enabled, max {max_open_pull_requests} open per user")
+        else:
+            print("Setting pull request creation cap to enabled")
+    else:
+        print("Disabling pull request creation cap")
+
+    if not self.noop("pr_creation_cap"):
+        self.ghrepo._requester.requestJson("PATCH", _creation_cap_url(self), input=payload)

--- a/asfyaml/feature/github/pr_creation_cap.py
+++ b/asfyaml/feature/github/pr_creation_cap.py
@@ -23,6 +23,7 @@ https://github.com/community/maintainers/discussions/840 and
 https://docs.github.com/rest/interactions/repos#update-pull-request-creation-cap-for-a-repository
 """
 
+import json
 from typing import Any
 
 from . import directive, ASFGitHubFeature
@@ -36,6 +37,29 @@ def _creation_cap_url(self: ASFGitHubFeature) -> str:
     return f"/repos/{self.repository.org_id}/{self.repository.name}/interaction-limits/pulls/creation-cap"
 
 
+def _check_creation_cap_response(self: ASFGitHubFeature, status: int, body: str) -> None:
+    """Raise unless GitHub accepted the creation cap update."""
+    if 200 <= status < 300:
+        return
+    try:
+        parsed = json.loads(body)
+        detail = str(parsed.get("errors") or parsed.get("message") or body)
+    except (json.JSONDecodeError, AttributeError):
+        detail = body
+    repo = f"{self.repository.org_id}/{self.repository.name}"
+    match status:
+        case 403:
+            raise Exception(f"Not allowed to set the pull request creation cap on '{repo}': {detail}")
+        case 404:
+            raise Exception(f"Repository '{repo}' not found or not accessible: {detail}")
+        case 422:
+            raise Exception(f"Validation failed while setting the pull request creation cap: {detail}")
+        case 500:
+            raise Exception(f"GitHub server error while setting the pull request creation cap: {detail}")
+        case _:
+            raise Exception(f"Unexpected response while setting the pull request creation cap: HTTP {status}: {detail}")
+
+
 @directive
 def pr_creation_cap(self: ASFGitHubFeature):
     pull_requests = self.yaml.get("pull_requests") or {}
@@ -47,6 +71,8 @@ def pr_creation_cap(self: ASFGitHubFeature):
 
     if creation_cap:
         enabled = creation_cap.get("enabled", False)
+        # Optional: when omitted (None), the key is left out of the payload below and
+        # GitHub applies its own default cap.
         max_open_pull_requests = creation_cap.get("max_open_pull_requests")
     elif was_previously_configured:
         # The section was removed; disable the cap that .asf.yaml previously managed.
@@ -76,4 +102,5 @@ def pr_creation_cap(self: ASFGitHubFeature):
         print("Disabling pull request creation cap")
 
     if not self.noop("pr_creation_cap"):
-        self.ghrepo._requester.requestJson("PATCH", _creation_cap_url(self), input=payload)
+        status, _headers, body = self.ghrepo._requester.requestJson("PATCH", _creation_cap_url(self), input=payload)
+        _check_creation_cap_response(self, status, body)

--- a/tests/github_pr_creation_cap.py
+++ b/tests/github_pr_creation_cap.py
@@ -1,0 +1,227 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for .asf.yaml GitHub pull request creation cap feature."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import asfyaml.asfyaml
+import asfyaml.dataobjects
+from asfyaml.feature.github.pr_creation_cap import pr_creation_cap
+from helpers import YamlTest
+
+# Set .asf.yaml to debug mode
+asfyaml.asfyaml.DEBUG = True
+
+CAP_URL = "/repos/apache/infrastructure-asfyaml/interaction-limits/pulls/creation-cap"
+
+
+valid_creation_cap = YamlTest(
+    None,
+    None,
+    """
+github:
+    pull_requests:
+      creation_cap:
+        enabled: true
+        max_open_pull_requests: 5
+""",
+)
+
+valid_creation_cap_disabled = YamlTest(
+    None,
+    None,
+    """
+github:
+    pull_requests:
+      creation_cap:
+        enabled: false
+""",
+)
+
+invalid_creation_cap_type = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "when expecting an integer",
+    """
+github:
+    pull_requests:
+      creation_cap:
+        enabled: true
+        max_open_pull_requests: lots
+""",
+)
+
+
+class FakeRequester:
+    def __init__(self):
+        self.calls: list[dict[str, Any]] = []
+
+    def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
+        self.calls.append({"method": method, "url": url, "input": input})
+        return 200, {}, "{}"
+
+
+class FakeFeature:
+    def __init__(
+        self,
+        *,
+        yaml: dict[str, Any],
+        previous_yaml: dict[str, Any],
+        requester: FakeRequester,
+        noop_enabled: bool = False,
+    ):
+        self.yaml = yaml
+        self.previous_yaml = previous_yaml
+        self.repository = SimpleNamespace(org_id="apache", name="infrastructure-asfyaml")
+        self.ghrepo = SimpleNamespace(_requester=requester)
+        self._noop_enabled = noop_enabled
+
+    def noop(self, directive: str) -> bool:
+        if self._noop_enabled:
+            print(f"[github::{directive}] Not applying changes, noop mode active.")
+            return True
+        return False
+
+
+def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
+    print("[github] Testing pull request creation cap")
+
+    tests_to_run = (
+        valid_creation_cap,
+        valid_creation_cap_disabled,
+        invalid_creation_cap_type,
+    )
+
+    for test in tests_to_run:
+        with test.ctx():
+            a = asfyaml.asfyaml.ASFYamlInstance(
+                repo=test_repo, committer="humbedooh", config_data=test.yaml, branch=asfyaml.dataobjects.DEFAULT_BRANCH
+            )
+            a.environments_enabled.add("noop")
+            a.no_cache = True
+            a.run_parts()
+
+
+def test_enable_creation_cap_with_max():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": True, "max_open_pull_requests": 5}}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    pr_creation_cap(feature)
+
+    assert requester.calls == [
+        {"method": "PATCH", "url": CAP_URL, "input": {"enabled": True, "max_open_pull_requests": 5}}
+    ]
+
+
+def test_enable_creation_cap_without_max():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": True}}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    pr_creation_cap(feature)
+
+    assert requester.calls == [{"method": "PATCH", "url": CAP_URL, "input": {"enabled": True}}]
+
+
+def test_disable_creation_cap():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": False}}},
+        previous_yaml={"pull_requests": {"creation_cap": {"enabled": True, "max_open_pull_requests": 5}}},
+        requester=requester,
+    )
+
+    pr_creation_cap(feature)
+
+    assert requester.calls == [{"method": "PATCH", "url": CAP_URL, "input": {"enabled": False}}]
+
+
+def test_removed_section_disables_cap():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"allow_auto_merge": True}},
+        previous_yaml={"pull_requests": {"creation_cap": {"enabled": True, "max_open_pull_requests": 5}}},
+        requester=requester,
+    )
+
+    pr_creation_cap(feature)
+
+    assert requester.calls == [{"method": "PATCH", "url": CAP_URL, "input": {"enabled": False}}]
+
+
+def test_disabled_and_never_configured_is_noop():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": False}}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    pr_creation_cap(feature)
+
+    assert requester.calls == []
+
+
+def test_no_creation_cap_section_is_noop():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"allow_auto_merge": True}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    pr_creation_cap(feature)
+
+    assert requester.calls == []
+
+
+def test_out_of_range_max_raises():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": True, "max_open_pull_requests": 5000}}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, "must be between 1 and 1000", "").ctx():
+        pr_creation_cap(feature)
+
+    assert requester.calls == []
+
+
+def test_noop_mode_does_not_call_api(capsys):
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": True, "max_open_pull_requests": 5}}},
+        previous_yaml={},
+        requester=requester,
+        noop_enabled=True,
+    )
+
+    pr_creation_cap(feature)
+
+    captured = capsys.readouterr()
+    assert "noop mode active" in captured.out
+    assert requester.calls == []

--- a/tests/github_pr_creation_cap.py
+++ b/tests/github_pr_creation_cap.py
@@ -20,6 +20,8 @@
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 import asfyaml.asfyaml
 import asfyaml.dataobjects
 from asfyaml.feature.github.pr_creation_cap import pr_creation_cap
@@ -68,12 +70,14 @@ github:
 
 
 class FakeRequester:
-    def __init__(self):
+    def __init__(self, status: int = 200, body: str = "{}"):
         self.calls: list[dict[str, Any]] = []
+        self.status = status
+        self.body = body
 
     def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
         self.calls.append({"method": method, "url": url, "input": input})
-        return 200, {}, "{}"
+        return self.status, {}, self.body
 
 
 class FakeFeature:
@@ -209,6 +213,41 @@ def test_out_of_range_max_raises():
         pr_creation_cap(feature)
 
     assert requester.calls == []
+
+
+def test_204_response_is_accepted():
+    requester = FakeRequester(status=204, body="")
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": True, "max_open_pull_requests": 5}}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    pr_creation_cap(feature)
+
+    assert len(requester.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "status, body, expected",
+    [
+        (403, '{"message": "Resource not accessible by integration"}', "Not allowed to set the pull request"),
+        (404, '{"message": "Not Found"}', "not found or not accessible"),
+        (422, '{"message": "Validation Failed"}', "Validation failed while setting"),
+        (500, '{"message": "Server Error"}', "GitHub server error while setting"),
+        (418, "not json at all", "Unexpected response while setting"),
+    ],
+)
+def test_error_response_raises(status: int, body: str, expected: str):
+    requester = FakeRequester(status=status, body=body)
+    feature = FakeFeature(
+        yaml={"pull_requests": {"creation_cap": {"enabled": True, "max_open_pull_requests": 5}}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, expected, "").ctx():
+        pr_creation_cap(feature)
 
 
 def test_noop_mode_does_not_call_api(capsys):


### PR DESCRIPTION
## What

Implements support for GitHub's [pull request creation cap](https://github.com/community/maintainers/discussions/840)
— an interaction limit that caps how many open pull requests a user **without write access** may have
open at one time. Users with write access are unaffected.

It uses the `PATCH /repos/{owner}/{repo}/interaction-limits/pulls/creation-cap` endpoint (schema taken
from GitHub's OpenAPI description, since the REST docs were not yet published when the changelog went out).

## Configuration

Nested under the existing `github.pull_requests` block:

    github:
      pull_requests:
        creation_cap:
          enabled: true
          max_open_pull_requests: 5   # optional, 1-1000; GitHub default used if omitted

- `enabled: false` turns the cap off.
- Removing the `creation_cap` section disables a cap that was previously managed by `.asf.yaml`.

## Changes

- `asfyaml/feature/github/__init__.py` — `creation_cap` strictyaml schema + directive registration
- `asfyaml/feature/github/pr_creation_cap.py` — new directive (payload build, 1–1000 range validation,
  disable-on-removal, noop-aware, idempotent PATCH)
- `tests/github_pr_creation_cap.py` — 9 tests (schema validation + enable/disable/removal/out-of-range/noop)
- `README.md` — new "Pull request creation cap" subsection + ToC entry

## Testing

Full suite passes (105 tests), `ruff` and `mypy` clean on the new code.