### PR TITLE
Remove the release policy option to preserve download files

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ The remaining fields:
 | `manual_vote` | boolean | Conduct the vote manually. Mutually exclusive with `vote_mode`. |
 | `min_hours` | integer | Minimum hours a vote must remain open. |
 | `license_check_mode` | `Both`, `Lightweight` or `RAT` | Which license check(s) to run. |
-| `preserve_download_files` | boolean | Keep download files after a release completes. |
 | `source_artifact_paths` | list of globs | Paths identifying source artifacts. |
 | `binary_artifact_paths` | list of globs | Paths identifying binary artifacts. |
 | `source_excludes_lightweight` | list of globs | Paths excluded from the lightweight license check. |

--- a/asfyaml/feature/project.py
+++ b/asfyaml/feature/project.py
@@ -96,7 +96,6 @@ _POLICY_SCHEMA = strictyaml.Map(
         strictyaml.Optional("announce_recipients"): _RECIPIENTS_SCHEMA,
         strictyaml.Optional("manual_vote"): strictyaml.Bool(),
         strictyaml.Optional("min_hours"): strictyaml.Int(),
-        strictyaml.Optional("preserve_download_files"): strictyaml.Bool(),
         strictyaml.Optional("release_checklist"): strictyaml.Str(),
         strictyaml.Optional("source_artifact_paths"): strictyaml.Seq(strictyaml.Str()),
         strictyaml.Optional("source_excludes_lightweight"): strictyaml.Seq(strictyaml.Str()),

--- a/tests/project_metadata.py
+++ b/tests/project_metadata.py
@@ -204,7 +204,6 @@ project:
         vote_recipients:
             to: private@tooling.apache.org
         min_hours: 72
-        preserve_download_files: true
         vote_mode: email
 """,
 )
@@ -493,7 +492,7 @@ project:
         name: Apache Trusted Releases
     policy:
         min_hours: 72
-        preserve_download_files: true
+        manual_vote: true
         license_check_mode: RAT
         binary_artifact_paths:
             - dist/*.jar
@@ -511,7 +510,7 @@ project:
     out = capsys.readouterr().out
     policy = json.loads(out[out.index("{") : out.rindex("}") + 1])["policy"]
     assert policy["min_hours"] == 72  # int, not "72"
-    assert policy["preserve_download_files"] is True  # bool, not "true"
+    assert policy["manual_vote"] is True  # bool, not "true"
     assert policy["license_check_mode"] == "RAT"
     assert policy["binary_artifact_paths"] == ["dist/*.jar"]
     assert policy["file_tag_mappings"] == {"sources": ["*.tar.gz"]}


### PR DESCRIPTION
We're removing the `downloads` directory from ATR. As such, the `preserve_download_files` option will no longer make sense as there will be nothing for it to reply to. We will be removing this property from ATR.
