### PR TITLE
Add restrict_update convenience key to prevent tags from being moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,8 +889,9 @@ Notes:
 - `required_status_checks_strict` defaults to `false` (set it to `true` to require branches to be up to date before merge).
 - If `branches`/`refs` is omitted for `type: branch`, it defaults to `~DEFAULT_BRANCH`.
 - `restrict_deletion` and `restrict_force_push` default to `true` in convenience syntax.
-- Set `restrict_deletion: false` and/or `restrict_force_push: false` to disable those rules for a convenience entry.
-- `deletion` and `non_fast_forward` are raw rule types under `rules`, not convenience top-level keys.
+- `restrict_update` defaults to `true` for `type: tag` and to `false` for `type: branch`.
+- Set `restrict_deletion: false`, `restrict_force_push: false` and/or `restrict_update: false` to disable those rules for a convenience entry.
+- `deletion`, `non_fast_forward` and `update` are raw rule types under `rules`, not convenience top-level keys.
 - Convenience entries may intentionally resolve to `rules: []` (for example, while staging migration changes).
 - If `required_conversation_resolution` is set, `required_pull_request_reviews` must be present as well.
 
@@ -974,6 +975,9 @@ github:
           - "v*.*.*"
         excludes: []
 ~~~
+
+By default, a tag ruleset blocks deletion, force-pushes, and updates of matching tags for everyone without bypass permission,
+matching the semantics of the old `protected_tags` setting.
 
 <h3 id="merge">Merge buttons</h3>
 

--- a/asfyaml/feature/github/rulesets.py
+++ b/asfyaml/feature/github/rulesets.py
@@ -35,6 +35,7 @@ _CONVENIENCE_RULESET_KEYS = {
     "bypass_mode",
     "restrict_deletion",
     "restrict_force_push",
+    "restrict_update",
     "required_signatures",
     "required_linear_history",
     "required_conversation_resolution",
@@ -413,9 +414,9 @@ def _is_raw_ruleset_definition(ruleset: dict[str, Any]) -> bool:
     return any(key in ruleset for key in _RAW_RULESET_KEYS)
 
 
-def _is_safety_rule_enabled(ruleset: dict[str, Any], field_name: str) -> bool:
+def _is_safety_rule_enabled(ruleset: dict[str, Any], field_name: str, *, default: bool = True) -> bool:
     if field_name not in ruleset:
-        return True
+        return default
     return _expect_bool(ruleset.get(field_name), field_name)
 
 
@@ -495,6 +496,8 @@ def _to_payload_ruleset(
         rules.append({"type": "deletion"})
     if _is_safety_rule_enabled(ruleset, "restrict_force_push"):
         rules.append({"type": "non_fast_forward"})
+    if _is_safety_rule_enabled(ruleset, "restrict_update", default=(target == "tag")):
+        rules.append({"type": "update"})
 
     pull_request_rule = _build_pull_request_rule(ruleset)
     if pull_request_rule:

--- a/tests/github_rulesets.py
+++ b/tests/github_rulesets.py
@@ -425,6 +425,7 @@ def test_rulesets_convenience_tag_restrict_force_push_rule():
     rule_types = [rule["type"] for rule in payload["rules"]]
     assert "deletion" in rule_types
     assert "non_fast_forward" in rule_types
+    assert "update" in rule_types
 
 
 def test_rulesets_convenience_minimal_config_includes_safety_rules():
@@ -447,6 +448,101 @@ def test_rulesets_convenience_minimal_config_includes_safety_rules():
     payload = requester.calls[1]["input"]
     rule_types = [rule["type"] for rule in payload["rules"]]
     assert rule_types == ["deletion", "non_fast_forward"]
+
+
+def test_rulesets_convenience_minimal_tag_config_includes_safety_rules():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Tag safety defaults only",
+                    "type": "tag",
+                    "branches": {"includes": ["v*.*.*"]},
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert rule_types == ["deletion", "non_fast_forward", "update"]
+
+
+def test_rulesets_convenience_restrict_update_false_disables_tag_rule():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Release tags",
+                    "type": "tag",
+                    "branches": {"includes": ["v*.*.*"]},
+                    "restrict_update": False,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert rule_types == ["deletion", "non_fast_forward"]
+
+
+def test_rulesets_convenience_restrict_update_true_enables_branch_rule():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Branch Protection",
+                    "type": "branch",
+                    "restrict_update": True,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    rule_types = [rule["type"] for rule in payload["rules"]]
+    assert rule_types == ["deletion", "non_fast_forward", "update"]
+
+
+def test_rulesets_convenience_all_safety_rules_false_allows_empty_tag_rules():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "rulesets": [
+                {
+                    "name": "Release tags",
+                    "type": "tag",
+                    "branches": {"includes": ["v*.*.*"]},
+                    "restrict_deletion": False,
+                    "restrict_force_push": False,
+                    "restrict_update": False,
+                }
+            ]
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    configure_rulesets(feature)
+
+    payload = requester.calls[1]["input"]
+    assert payload["rules"] == []
 
 
 def test_rulesets_convenience_restrict_deletion_false_disables_rule():
@@ -523,15 +619,19 @@ def test_rulesets_convenience_both_safety_rules_false_allows_empty_rules():
 
 
 @pytest.mark.parametrize(
-    ("field_name", "field_value"),
+    ("field_name", "field_value", "expected_rule_type"),
     [
-        ("restrict_deletion", True),
-        ("restrict_deletion", "true"),
-        ("restrict_force_push", True),
-        ("restrict_force_push", "true"),
+        ("restrict_deletion", True, "deletion"),
+        ("restrict_deletion", "true", "deletion"),
+        ("restrict_force_push", True, "non_fast_forward"),
+        ("restrict_force_push", "true", "non_fast_forward"),
+        ("restrict_update", True, "update"),
+        ("restrict_update", "true", "update"),
     ],
 )
-def test_rulesets_convenience_allow_explicit_safety_true(field_name: str, field_value: bool | str):
+def test_rulesets_convenience_allow_explicit_safety_true(
+    field_name: str, field_value: bool | str, expected_rule_type: str
+):
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -552,13 +652,12 @@ def test_rulesets_convenience_allow_explicit_safety_true(field_name: str, field_
 
     payload = requester.calls[1]["input"]
     rule_types = [rule["type"] for rule in payload["rules"]]
-    assert "deletion" in rule_types
-    assert "non_fast_forward" in rule_types
+    assert expected_rule_type in rule_types
 
 
 @pytest.mark.parametrize(
     "field_name",
-    ["restrict_deletion", "restrict_force_push"],
+    ["restrict_deletion", "restrict_force_push", "restrict_update"],
 )
 def test_rulesets_convenience_reject_invalid_safety_type(field_name: str):
     requester = FakeRequester()
@@ -800,7 +899,11 @@ def test_rulesets_duplicate_names_raise():
         configure_rulesets(feature)
 
 
-def test_rulesets_mixed_raw_and_convenience_keys_raise():
+@pytest.mark.parametrize(
+    "convenience_key",
+    ["required_signatures", "restrict_update"],
+)
+def test_rulesets_mixed_raw_and_convenience_keys_raise(convenience_key: str):
     requester = FakeRequester()
     feature = FakeFeature(
         yaml={
@@ -809,7 +912,7 @@ def test_rulesets_mixed_raw_and_convenience_keys_raise():
                     "name": "Branch Protection",
                     "target": "branch",
                     "rules": [{"type": "required_signatures"}],
-                    "required_signatures": True,
+                    convenience_key: True,
                 }
             ]
         },


### PR DESCRIPTION
## Summary

Tag rulesets written in the convenience syntax now emit GitHub's `update` rule by default, via a new `restrict_update` convenience key. This prevents existing tags from being moved to a different commit by anyone without bypass permission, matching the semantics of the deprecated `protected_tags` setting.

Defaults differ by target:

- `type: branch`: `restrict_deletion` and `restrict_force_push` remain enabled by default (unchanged); `restrict_update` defaults to `false`, since an `update` rule on branches would block all pushes for non-bypass actors.
- `type: tag`: additionally enables `restrict_update` by default.

Both targets can override the defaults explicitly (`restrict_update: true` on branches, `restrict_update: false` on tags).

## Motivation

As part of apache/logging-parent#477, the Logging Services project is migrating its branch and tag protection to rulesets. Without an `update` rule, a convenience-syntax tag ruleset protects tags from deletion and force-pushes, but not from being moved, so tag rules had to be written in the raw payload syntax. With this change, tag rules can be expressed entirely in the convenience format.

## Changes

- `restrict_update` added to the convenience key set (recognized in convenience entries, rejected when mixed into raw payloads).
- `_is_safety_rule_enabled()` gained a target-aware default, used to emit `{"type": "update"}`.
- Tests: minimal tag entries now assert exactly `["deletion", "non_fast_forward", "update"]`, plus coverage for explicit true/false on both targets, invalid types, and mixed raw/convenience rejection.
- README: documented the per-target default and noted that tag rulesets now match the old `protected_tags` semantics out of the box.

Raw payload entries are unaffected.

Fixes #96
