### PR TITLE
Add github.code_scanning for CodeQL default setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,12 @@ github:
 The `languages` values are the [CodeQL language identifiers](https://docs.github.com/en/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration) accepted by GitHub,
 currently `actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby` and `swift`.
 
+Setting `code_scanning: false`,
+or removing the section,
+disables the default setup,
+but only if it was previously managed through `.asf.yaml`.
+A setup enabled by INFRA is left untouched.
+
 > [!WARNING]
 > Projects with an existing *advanced setup* (a committed CodeQL workflow file) should not enable default setup, as the two approaches conflict.
 

--- a/README.md
+++ b/README.md
@@ -861,12 +861,20 @@ github:
     query_suite: extended       # optional, "default" or "extended", left unmanaged if omitted
     threat_model: remote        # optional, "remote" or "remote_and_local", left unmanaged if omitted
     languages:                  # optional, restricts analysis to these languages;
-      - java-kotlin             # if omitted, GitHub auto-detects eligible languages
+      - java-kotlin             # selected automatically by GitHub if never set
       - python
 ~~~
 
 The `languages` values are the [CodeQL language identifiers](https://docs.github.com/en/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration) accepted by GitHub,
 currently `actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby` and `swift`.
+
+Settings applied through `.asf.yaml` stick on GitHub's side:
+removing a key from the map keeps its last applied value,
+it does not revert it.
+To change the analyzed languages, list them explicitly.
+To return to fully automatic language selection,
+disable the setup and re-enable it in a later commit;
+note that this also resets `query_suite` and `threat_model` to their GitHub defaults.
 
 Setting `code_scanning: false`,
 or removing the section,

--- a/README.md
+++ b/README.md
@@ -868,11 +868,6 @@ github:
 The `languages` values are the [CodeQL language identifiers](https://docs.github.com/en/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration) accepted by GitHub,
 currently `actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby` and `swift`.
 
-Code scanning requires GitHub Actions to be enabled on the repository.
-Removing (or commenting out) the `code_scanning` section disables default setup again,
-but only if it was previously managed via `.asf.yaml`;
-a setup enabled manually through the GitHub UI is left untouched.
-
 > [!WARNING]
 > Projects with an existing *advanced setup* (a committed CodeQL workflow file) should not enable default setup, as the two approaches conflict.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ It operates on a per-branch basis, meaning you can have different settings for d
       <li><a href="#pages">GitHub Pages</a></li>
       <li><a href="#pull_requests">Pull Request settings</a></li>
       <li><a href="#copilot_code_review">Copilot code review</a></li>
+      <li><a href="#code_scanning">Code scanning (CodeQL)</a></li>
       <li><a href="#rulesets">Rulesets</a></li>
       <li><a href="#merge">Merge buttons</a></li>
       <li><a href="#repo_features">Repository features</a></li>
@@ -839,6 +840,41 @@ Set `enabled: false` to disable this behavior. Removing the `copilot_code_review
 As an alternative, you can configure Copilot review through [`rulesets`](#rulesets). Validation fails if both
 `copilot_code_review` and `rulesets` overlap, either by managing a ruleset named `Copilot Code Review`
 or by defining a `copilot_code_review` rule type in `rulesets`.
+
+<h3 id="code_scanning">Code scanning (CodeQL)</h3>
+
+Projects can enable [code scanning with CodeQL default setup](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning) on their repository.
+GitHub automatically analyzes the code on pushes and pull requests,
+and alerts appear under the repository's Security tab:
+
+~~~yaml
+github:
+  code_scanning: true
+~~~
+
+For more control over the setup, use a map of settings instead of a boolean
+(its presence implies that code scanning is enabled):
+
+~~~yaml
+github:
+  code_scanning:
+    query_suite: extended       # optional, "default" or "extended", default "default"
+    threat_model: remote        # optional, "remote" or "remote_and_local", left unmanaged if omitted
+    languages:                  # optional, restricts analysis to these languages;
+      - java-kotlin             # if omitted, GitHub auto-detects eligible languages
+      - python
+~~~
+
+The `languages` values are the [CodeQL language identifiers](https://docs.github.com/en/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration) accepted by GitHub,
+currently `actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby` and `swift`.
+
+Code scanning requires GitHub Actions to be enabled on the repository.
+Removing (or commenting out) the `code_scanning` section disables default setup again,
+but only if it was previously managed via `.asf.yaml`;
+a setup enabled manually through the GitHub UI is left untouched.
+
+> [!WARNING]
+> Projects with an existing *advanced setup* (a committed CodeQL workflow file) should not enable default setup, as the two approaches conflict.
 
 <h3 id="rulesets">Rulesets</h3>
 

--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ For more control over the setup, use a map of settings instead of a boolean
 ~~~yaml
 github:
   code_scanning:
-    query_suite: extended       # optional, "default" or "extended", default "default"
+    query_suite: extended       # optional, "default" or "extended", left unmanaged if omitted
     threat_model: remote        # optional, "remote" or "remote_and_local", left unmanaged if omitted
     languages:                  # optional, restricts analysis to these languages;
       - java-kotlin             # if omitted, GitHub auto-detects eligible languages

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -150,6 +150,16 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
                     strictyaml.Optional("review_on_push", default=False): strictyaml.Bool(),
                 }
             ),
+            # CodeQL code scanning default setup: "true" for a simple setup, or a map of settings
+            strictyaml.Optional("code_scanning"): strictyaml.Bool()
+            | strictyaml.Map(
+                {
+                    strictyaml.Optional("query_suite", default="default"): strictyaml.Enum(["default", "extended"]),
+                    strictyaml.Optional("threat_model"): strictyaml.Enum(["remote", "remote_and_local"]),
+                    # Language identifiers are validated by GitHub, not here, as the set grows over time.
+                    strictyaml.Optional("languages"): strictyaml.UniqueSeq(strictyaml.Str()),
+                }
+            ),
             # Delete branch on merge
             # TODO: deprecated, use "pull_requests.del_branch_on_merge" instead
             strictyaml.Optional("del_branch_on_merge"): strictyaml.Bool(),
@@ -275,4 +285,5 @@ from . import (
     deployment_environments,
     rulesets,
     copilot_code_review,
+    code_scanning,
 )

--- a/asfyaml/feature/github/__init__.py
+++ b/asfyaml/feature/github/__init__.py
@@ -154,7 +154,7 @@ class ASFGitHubFeature(ASFYamlFeature, name="github"):
             strictyaml.Optional("code_scanning"): strictyaml.Bool()
             | strictyaml.Map(
                 {
-                    strictyaml.Optional("query_suite", default="default"): strictyaml.Enum(["default", "extended"]),
+                    strictyaml.Optional("query_suite"): strictyaml.Enum(["default", "extended"]),
                     strictyaml.Optional("threat_model"): strictyaml.Enum(["remote", "remote_and_local"]),
                     # Language identifiers are validated by GitHub, not here, as the set grows over time.
                     strictyaml.Optional("languages"): strictyaml.UniqueSeq(strictyaml.Str()),

--- a/asfyaml/feature/github/code_scanning.py
+++ b/asfyaml/feature/github/code_scanning.py
@@ -39,7 +39,13 @@ def get_default_setup(self: ASFGitHubFeature) -> dict[str, Any]:
     status, _headers, body = self.ghrepo._requester.requestJson("GET", _default_setup_endpoint(self))
     repo = f"{self.repository.org_id}/{self.repository.name}"
     if status == 200:
-        payload = json.loads(body)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            raise Exception(
+                f"Unexpected response format while fetching code scanning default setup: "
+                f"expected JSON, got: {body[:200]}"
+            )
         if isinstance(payload, dict):
             return payload
         raise Exception(
@@ -58,7 +64,7 @@ def get_default_setup(self: ASFGitHubFeature) -> dict[str, Any]:
 
 def update_default_setup(self: ASFGitHubFeature, payload: dict[str, Any]) -> None:
     status, _headers, body = self.ghrepo._requester.requestJson("PATCH", _default_setup_endpoint(self), input=payload)
-    if status in (200, 202):
+    if 200 <= status < 300:
         return
     detail = _parse_detail(body)
     repo = f"{self.repository.org_id}/{self.repository.name}"

--- a/asfyaml/feature/github/code_scanning.py
+++ b/asfyaml/feature/github/code_scanning.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""GitHub code scanning (CodeQL default setup) support."""
+
+import json
+from typing import Any
+
+from . import directive, ASFGitHubFeature
+
+
+def _default_setup_endpoint(self: ASFGitHubFeature) -> str:
+    return f"/repos/{self.repository.org_id}/{self.repository.name}/code-scanning/default-setup"
+
+
+def _parse_detail(body: str) -> str:
+    try:
+        parsed = json.loads(body)
+        return str(parsed.get("errors") or parsed.get("message") or body)
+    except (json.JSONDecodeError, AttributeError):
+        return body
+
+
+def get_default_setup(self: ASFGitHubFeature) -> dict[str, Any]:
+    status, _headers, body = self.ghrepo._requester.requestJson("GET", _default_setup_endpoint(self))
+    repo = f"{self.repository.org_id}/{self.repository.name}"
+    if status == 200:
+        payload = json.loads(body)
+        if isinstance(payload, dict):
+            return payload
+        raise Exception(
+            f"Unexpected response format while fetching code scanning default setup: "
+            f"expected an object, got {type(payload).__name__}"
+        )
+    detail = _parse_detail(body)
+    match status:
+        case 403:
+            raise Exception(f"Code scanning is not permitted for repository '{repo}': {detail}")
+        case 404:
+            raise Exception(f"Code scanning is not available for repository '{repo}': {detail}")
+        case _:
+            raise Exception(f"Unexpected response while fetching code scanning default setup: HTTP {status}: {detail}")
+
+
+def update_default_setup(self: ASFGitHubFeature, payload: dict[str, Any]) -> None:
+    status, _headers, body = self.ghrepo._requester.requestJson("PATCH", _default_setup_endpoint(self), input=payload)
+    if status in (200, 202):
+        return
+    detail = _parse_detail(body)
+    repo = f"{self.repository.org_id}/{self.repository.name}"
+    match status:
+        case 403:
+            raise Exception(
+                f"Code scanning is not permitted for repository '{repo}' (the repository may be archived): {detail}"
+            )
+        case 404:
+            raise Exception(f"Code scanning is not available for repository '{repo}': {detail}")
+        case 409:
+            raise Exception(
+                f"Could not update code scanning default setup for '{repo}': a setup change is already "
+                f"in progress, or GitHub Actions is disabled for this repository. Ensure GitHub Actions "
+                f"is enabled and try again later: {detail}"
+            )
+        case 422:
+            raise Exception(
+                f"Validation failed while updating code scanning default setup for '{repo}': {detail}. "
+                "Note that CodeQL default setup requires at least one CodeQL-supported language in the repository."
+            )
+        case _:
+            raise Exception(f"Unexpected response while updating code scanning default setup: HTTP {status}: {detail}")
+
+
+def _matches_current(current: dict[str, Any], desired: dict[str, Any]) -> bool:
+    """True if every field in the desired PATCH payload already matches the GET response.
+
+    Fields absent from the payload (auto-detected languages, unmanaged threat_model)
+    are not compared; languages compare as sets."""
+    for key, value in desired.items():
+        if key == "languages":
+            if set(value) != set(current.get("languages") or []):
+                return False
+        elif current.get(key) != value:
+            return False
+    return True
+
+
+@directive
+def code_scanning(self: ASFGitHubFeature):
+    scanning = self.yaml.get("code_scanning")
+    previous_yaml = self.previous_yaml if isinstance(self.previous_yaml, dict) else {}
+    was_previously_configured = "code_scanning" in previous_yaml
+
+    settings: dict[str, Any] = {}
+    if scanning is None:
+        if not was_previously_configured:
+            # Never managed by .asf.yaml, leave repository settings untouched.
+            return
+        # Section removed after having been managed by .asf.yaml: disable the setup.
+        enabled = False
+    elif isinstance(scanning, bool):
+        # Simple form: code_scanning: true/false
+        enabled = scanning
+    else:
+        # Map form: the presence of settings implies the setup is enabled.
+        enabled = True
+        settings = scanning
+
+    if self.noop("code_scanning"):
+        return
+
+    current = get_default_setup(self)
+    currently_configured = current.get("state") == "configured"
+
+    if enabled:
+        desired: dict[str, Any] = {
+            "state": "configured",
+            "query_suite": settings.get("query_suite", "default"),
+        }
+        # Fields not specified in .asf.yaml are left for GitHub to manage (auto-detection).
+        if "threat_model" in settings:
+            desired["threat_model"] = settings["threat_model"]
+        if "languages" in settings:
+            desired["languages"] = list(settings["languages"])
+        if currently_configured and _matches_current(current, desired):
+            return
+        print(f"[github] Enabling CodeQL code scanning default setup (query_suite={desired['query_suite']})")
+        update_default_setup(self, desired)
+    else:
+        if not currently_configured:
+            return
+        print("[github] Disabling CodeQL code scanning default setup")
+        update_default_setup(self, {"state": "not-configured"})

--- a/asfyaml/feature/github/code_scanning.py
+++ b/asfyaml/feature/github/code_scanning.py
@@ -106,18 +106,18 @@ def code_scanning(self: ASFGitHubFeature):
 
     settings: dict[str, Any] = {}
     if scanning is None:
-        if not was_previously_configured:
-            # Never managed by .asf.yaml, leave repository settings untouched.
-            return
-        # Section removed after having been managed by .asf.yaml: disable the setup.
-        enabled = False
+        # Section absent
+        configured = False
     elif isinstance(scanning, bool):
         # Simple form: code_scanning: true/false
-        enabled = scanning
+        configured = scanning
     else:
         # Map form: the presence of settings implies the setup is enabled.
-        enabled = True
+        configured = True
         settings = scanning
+
+    if not configured and not was_previously_configured:
+        return
 
     if self.noop("code_scanning"):
         return
@@ -125,7 +125,7 @@ def code_scanning(self: ASFGitHubFeature):
     current = get_default_setup(self)
     currently_configured = current.get("state") == "configured"
 
-    if enabled:
+    if configured:
         desired: dict[str, Any] = {
             "state": "configured",
             "query_suite": settings.get("query_suite", "default"),

--- a/asfyaml/feature/github/code_scanning.py
+++ b/asfyaml/feature/github/code_scanning.py
@@ -143,7 +143,9 @@ def code_scanning(self: ASFGitHubFeature):
             desired["languages"] = list(settings["languages"])
         if currently_configured and _matches_current(current, desired):
             return
-        print(f"[github] Enabling CodeQL code scanning default setup (query_suite={desired.get('query_suite', 'unmanaged')})")
+        print(
+            f"[github] Enabling CodeQL code scanning default setup (query_suite={desired.get('query_suite', 'unmanaged')})"
+        )
         update_default_setup(self, desired)
     else:
         if not currently_configured:

--- a/asfyaml/feature/github/code_scanning.py
+++ b/asfyaml/feature/github/code_scanning.py
@@ -84,12 +84,13 @@ def update_default_setup(self: ASFGitHubFeature, payload: dict[str, Any]) -> Non
             raise Exception(f"Unexpected response while updating code scanning default setup: HTTP {status}: {detail}")
 
 
-def _matches_current(current: dict[str, Any], desired: dict[str, Any]) -> bool:
-    """True if every field in the desired PATCH payload already matches the GET response.
+def _matches_current(current: dict[str, Any], diff: dict[str, Any]) -> bool:
+    """True if every field explicitly set in the PATCH diff already has the same value
+    in the current GET response.
 
-    Fields absent from the payload (auto-detected languages, unmanaged threat_model)
-    are not compared; languages compare as sets."""
-    for key, value in desired.items():
+    Fields absent from the diff (unmanaged query_suite/threat_model, auto-detected
+    languages) are not compared; languages compare as sets."""
+    for key, value in diff.items():
         if key == "languages":
             if set(value) != set(current.get("languages") or []):
                 return False
@@ -126,18 +127,17 @@ def code_scanning(self: ASFGitHubFeature):
     currently_configured = current.get("state") == "configured"
 
     if configured:
-        desired: dict[str, Any] = {
-            "state": "configured",
-            "query_suite": settings.get("query_suite", "default"),
-        }
+        desired: dict[str, Any] = {"state": "configured"}
         # Fields not specified in .asf.yaml are left for GitHub to manage (auto-detection).
+        if "query_suite" in settings:
+            desired["query_suite"] = settings["query_suite"]
         if "threat_model" in settings:
             desired["threat_model"] = settings["threat_model"]
         if "languages" in settings:
             desired["languages"] = list(settings["languages"])
         if currently_configured and _matches_current(current, desired):
             return
-        print(f"[github] Enabling CodeQL code scanning default setup (query_suite={desired['query_suite']})")
+        print(f"[github] Enabling CodeQL code scanning default setup (query_suite={desired.get('query_suite', 'unmanaged')})")
         update_default_setup(self, desired)
     else:
         if not currently_configured:

--- a/tests/github_code_scanning.py
+++ b/tests/github_code_scanning.py
@@ -116,6 +116,7 @@ class FakeRequester:
         languages: list[str] | None = None,
         patch_status: int = 200,
         patch_body: str = "{}",
+        get_body: str | None = None,
     ):
         self.state = state
         self.query_suite = query_suite
@@ -123,11 +124,14 @@ class FakeRequester:
         self.languages = languages or []
         self.patch_status = patch_status
         self.patch_body = patch_body
+        self.get_body = get_body
         self.calls: list[dict[str, Any]] = []
 
     def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
         self.calls.append({"method": method, "url": url, "input": input})
         if method == "GET":
+            if self.get_body is not None:
+                return 200, {}, self.get_body
             return (
                 200,
                 {},
@@ -314,6 +318,31 @@ def test_patch_202_accepted_is_success():
     code_scanning(feature)
 
     assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+
+
+def test_patch_other_2xx_is_success():
+    requester = FakeRequester(patch_status=204, patch_body="")
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+
+
+def test_get_non_json_raises_helpful_error():
+    requester = FakeRequester(get_body="<html>Service unavailable</html>")
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, "expected JSON", "").ctx():
+        code_scanning(feature)
 
 
 def test_disable_patches_not_configured():

--- a/tests/github_code_scanning.py
+++ b/tests/github_code_scanning.py
@@ -1,0 +1,423 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for .asf.yaml GitHub code scanning (CodeQL default setup) feature."""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import asfyaml.asfyaml
+import asfyaml.dataobjects
+from asfyaml.feature.github.code_scanning import code_scanning
+from helpers import YamlTest
+
+# Set .asf.yaml to debug mode
+asfyaml.asfyaml.DEBUG = True
+
+
+valid_code_scanning_simple = YamlTest(
+    None,
+    None,
+    """
+github:
+    code_scanning: true
+""",
+)
+
+valid_code_scanning_disabled = YamlTest(
+    None,
+    None,
+    """
+github:
+    code_scanning: false
+""",
+)
+
+valid_code_scanning_all_settings = YamlTest(
+    None,
+    None,
+    """
+github:
+    code_scanning:
+      query_suite: extended
+      threat_model: remote_and_local
+      languages:
+        - java-kotlin
+        - python
+        - some-future-language
+""",
+)
+
+invalid_code_scanning_query_suite = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "when expecting one of",
+    """
+github:
+    code_scanning:
+      query_suite: paranoid
+""",
+)
+
+invalid_code_scanning_threat_model = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "when expecting one of",
+    """
+github:
+    code_scanning:
+      threat_model: local
+""",
+)
+
+invalid_code_scanning_duplicate_language = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "duplicate found",
+    """
+github:
+    code_scanning:
+      languages:
+        - python
+        - python
+""",
+)
+
+invalid_code_scanning_unknown_key = YamlTest(
+    asfyaml.asfyaml.ASFYAMLException,
+    "unexpected key not in schema",
+    """
+github:
+    code_scanning:
+      enabled: true
+""",
+)
+
+
+class FakeRequester:
+    def __init__(
+        self,
+        *,
+        state: str = "not-configured",
+        query_suite: str | None = None,
+        threat_model: str | None = None,
+        languages: list[str] | None = None,
+        patch_status: int = 200,
+        patch_body: str = "{}",
+    ):
+        self.state = state
+        self.query_suite = query_suite
+        self.threat_model = threat_model
+        self.languages = languages or []
+        self.patch_status = patch_status
+        self.patch_body = patch_body
+        self.calls: list[dict[str, Any]] = []
+
+    def requestJson(self, method: str, url: str, input: dict[str, Any] | None = None):  # noqa: N802
+        self.calls.append({"method": method, "url": url, "input": input})
+        if method == "GET":
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "state": self.state,
+                        "query_suite": self.query_suite,
+                        "threat_model": self.threat_model,
+                        "languages": self.languages,
+                        "updated_at": None,
+                        "schedule": None,
+                    }
+                ),
+            )
+        return self.patch_status, {}, self.patch_body
+
+
+class FakeFeature:
+    def __init__(
+        self,
+        *,
+        yaml: dict[str, Any],
+        previous_yaml: dict[str, Any],
+        requester: FakeRequester,
+        noop_enabled: bool = False,
+    ):
+        self.yaml = yaml
+        self.previous_yaml = previous_yaml
+        self.repository = SimpleNamespace(org_id="apache", name="infrastructure-asfyaml")
+        self.ghrepo = SimpleNamespace(_requester=requester)
+        self._noop_enabled = noop_enabled
+
+    def noop(self, directive: str) -> bool:
+        if self._noop_enabled:
+            print(f"[github::{directive}] Not applying changes, noop mode active.")
+            return True
+        return False
+
+
+DEFAULT_SETUP_URL = "/repos/apache/infrastructure-asfyaml/code-scanning/default-setup"
+
+
+def test_basic_yaml(test_repo: asfyaml.dataobjects.Repository):
+    print("[github] Testing code scanning")
+
+    tests_to_run = (
+        valid_code_scanning_simple,
+        valid_code_scanning_disabled,
+        valid_code_scanning_all_settings,
+        invalid_code_scanning_query_suite,
+        invalid_code_scanning_threat_model,
+        invalid_code_scanning_duplicate_language,
+        invalid_code_scanning_unknown_key,
+    )
+
+    for test in tests_to_run:
+        with test.ctx():
+            a = asfyaml.asfyaml.ASFYamlInstance(
+                repo=test_repo, committer="humbedooh", config_data=test.yaml, branch=asfyaml.dataobjects.DEFAULT_BRANCH
+            )
+            a.environments_enabled.add("noop")
+            a.no_cache = True
+            a.run_parts()
+
+
+def test_enable_configures_default_setup():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+    assert requester.calls[1]["url"] == DEFAULT_SETUP_URL
+    assert requester.calls[1]["input"] == {"state": "configured", "query_suite": "default"}
+
+
+def test_enable_with_all_settings():
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={
+            "code_scanning": {
+                "query_suite": "extended",
+                "threat_model": "remote_and_local",
+                "languages": ["java-kotlin", "python"],
+            }
+        },
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+    assert requester.calls[1]["input"] == {
+        "state": "configured",
+        "query_suite": "extended",
+        "threat_model": "remote_and_local",
+        "languages": ["java-kotlin", "python"],
+    }
+
+
+def test_enable_skips_when_already_configured():
+    requester = FakeRequester(state="configured", query_suite="default")
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET"]
+
+
+def test_enable_skips_ignores_unspecified_fields():
+    # GET reports auto-detected languages and a threat model; the yaml does not manage them.
+    requester = FakeRequester(
+        state="configured", query_suite="default", threat_model="remote", languages=["go", "python"]
+    )
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET"]
+
+
+def test_enable_skips_when_languages_match_in_different_order():
+    requester = FakeRequester(state="configured", query_suite="default", languages=["python", "go"])
+    feature = FakeFeature(
+        yaml={"code_scanning": {"query_suite": "default", "languages": ["go", "python"]}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET"]
+
+
+def test_query_suite_change_repatches():
+    requester = FakeRequester(state="configured", query_suite="default")
+    feature = FakeFeature(
+        yaml={"code_scanning": {"query_suite": "extended"}},
+        previous_yaml={"code_scanning": True},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+    assert requester.calls[1]["input"] == {"state": "configured", "query_suite": "extended"}
+
+
+def test_languages_change_repatches():
+    requester = FakeRequester(state="configured", query_suite="default", languages=["python"])
+    feature = FakeFeature(
+        yaml={"code_scanning": {"query_suite": "default", "languages": ["python", "go"]}},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+    assert requester.calls[1]["input"]["languages"] == ["python", "go"]
+
+
+def test_patch_202_accepted_is_success():
+    requester = FakeRequester(patch_status=202, patch_body='{"run_id": 42, "run_url": "https://example.invalid"}')
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+
+
+def test_disable_patches_not_configured():
+    requester = FakeRequester(state="configured", query_suite="default")
+    feature = FakeFeature(
+        # Never previously managed by .asf.yaml, but explicit intent wins.
+        yaml={"code_scanning": False},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+    assert requester.calls[1]["input"] == {"state": "not-configured"}
+
+
+def test_disable_skips_when_not_configured():
+    requester = FakeRequester(state="not-configured")
+    feature = FakeFeature(
+        yaml={"code_scanning": False},
+        previous_yaml={"code_scanning": True},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET"]
+
+
+def test_removed_section_disables_when_previously_managed():
+    requester = FakeRequester(state="configured", query_suite="default")
+    feature = FakeFeature(
+        yaml={},
+        previous_yaml={"code_scanning": True},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
+    assert requester.calls[1]["input"] == {"state": "not-configured"}
+
+
+def test_absent_section_untouched_when_never_managed():
+    requester = FakeRequester(state="configured", query_suite="default")
+    feature = FakeFeature(
+        yaml={},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert requester.calls == []
+
+
+def test_noop_mode_does_not_call_api(capsys):
+    requester = FakeRequester()
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+        noop_enabled=True,
+    )
+
+    code_scanning(feature)
+
+    captured = capsys.readouterr()
+    assert "noop mode active" in captured.out
+    assert requester.calls == []
+
+
+def test_patch_403_raises_helpful_error():
+    requester = FakeRequester(patch_status=403, patch_body='{"message": "Advanced Security is not enabled"}')
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, "not permitted", "").ctx():
+        code_scanning(feature)
+
+
+def test_patch_409_raises_helpful_error():
+    requester = FakeRequester(patch_status=409, patch_body='{"message": "default setup is already being enabled"}')
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, "already in progress", "").ctx():
+        code_scanning(feature)
+
+
+def test_patch_422_raises_helpful_error():
+    requester = FakeRequester(patch_status=422, patch_body='{"message": "no CodeQL supported languages found"}')
+    feature = FakeFeature(
+        yaml={"code_scanning": True},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    with YamlTest(Exception, "Validation failed", "").ctx():
+        code_scanning(feature)

--- a/tests/github_code_scanning.py
+++ b/tests/github_code_scanning.py
@@ -319,9 +319,8 @@ def test_patch_202_accepted_is_success():
 def test_disable_patches_not_configured():
     requester = FakeRequester(state="configured", query_suite="default")
     feature = FakeFeature(
-        # Never previously managed by .asf.yaml, but explicit intent wins.
         yaml={"code_scanning": False},
-        previous_yaml={},
+        previous_yaml={"code_scanning": True},
         requester=requester,
     )
 
@@ -329,6 +328,20 @@ def test_disable_patches_not_configured():
 
     assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
     assert requester.calls[1]["input"] == {"state": "not-configured"}
+
+
+def test_disable_skips_when_never_managed():
+    requester = FakeRequester(state="configured", query_suite="default")
+    feature = FakeFeature(
+        # Never managed by .asf.yaml: a setup enabled by INFRA is left untouched.
+        yaml={"code_scanning": False},
+        previous_yaml={},
+        requester=requester,
+    )
+
+    code_scanning(feature)
+
+    assert requester.calls == []
 
 
 def test_disable_skips_when_not_configured():

--- a/tests/github_code_scanning.py
+++ b/tests/github_code_scanning.py
@@ -205,7 +205,7 @@ def test_enable_configures_default_setup():
 
     assert [call["method"] for call in requester.calls] == ["GET", "PATCH"]
     assert requester.calls[1]["url"] == DEFAULT_SETUP_URL
-    assert requester.calls[1]["input"] == {"state": "configured", "query_suite": "default"}
+    assert requester.calls[1]["input"] == {"state": "configured"}
 
 
 def test_enable_with_all_settings():


### PR DESCRIPTION
Allows projects to self-service enable GitHub code scanning (CodeQL default setup) from `.asf.yaml`, as requested in #94 (code scanning part only; secret scanning can be a follow-up):

```yaml
github:
  code_scanning: true
```

or, for more control:

```yaml
github:
  code_scanning:
    query_suite: extended       # "default" or "extended"
    threat_model: remote        # "remote" or "remote_and_local"
    languages:                  # restricts analysis; auto-detected when omitted
      - java-kotlin
```

Design notes:

- The section's presence is the toggle (no `enabled` key), matching how `rulesets` works; a plain boolean is accepted for the simple case.
- The directive GETs `/repos/{org}/{repo}/code-scanning/default-setup` first and only PATCHes when the desired settings differ, so unrelated `.asf.yaml` edits do not re-trigger analysis runs, and both 200 and 202 (async validation run) are treated as success.
- Removing (or commenting out) the section disables the setup only if it was previously managed via `.asf.yaml` (same `previous_yaml` semantics as #121); a setup enabled manually through the GitHub UI is left untouched.
- `languages` values are deliberately not validated client-side, since GitHub extends the CodeQL language set over time; invalid values surface as a GitHub 422 relayed to the committer by email, as are the 403/409 cases (archived repo, setup change in progress, Actions disabled).
- Tests follow the `github_copilot_code_review.py` fake-requester pattern; README documents the new section.

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)