### PR TITLE
Add a workflow for testing parser changes against a sandbox repo

### DIFF
--- a/.github/workflows/sandbox-test.yaml
+++ b/.github/workflows/sandbox-test.yaml
@@ -141,7 +141,7 @@ jobs:
           fi
 
       - name: Check out the parser under test
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.resolve.outputs.ref }}
           path: parser

--- a/.github/workflows/sandbox-test.yaml
+++ b/.github/workflows/sandbox-test.yaml
@@ -195,7 +195,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/sandbox-test.yaml
+++ b/.github/workflows/sandbox-test.yaml
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
 
       - name: Check out the sandbox repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ steps.resolve.outputs.sandbox_repo }}
           ref: ${{ inputs.sandbox_branch }}

--- a/.github/workflows/sandbox-test.yaml
+++ b/.github/workflows/sandbox-test.yaml
@@ -1,0 +1,241 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Applies a given version of the .asf.yaml parser to a sandbox repository, so
+# that a change can be seen acting on a live GitHub repo before it is merged.
+# See docs/testing-a-change.md for the process.
+#
+# This runs in two places:
+#
+#   * In apache/infrastructure-asfyaml, where a committer tests a pull request
+#     before merging it. SECURITY: this checks out and executes code from an
+#     arbitrary ref -- including a PR opened from a fork -- with a token that has
+#     admin rights on the Apache sandbox repo. Only a committer can start it, and
+#     that committer is the security control: read the diff of the exact commit
+#     you are about to run. The commit SHA is recorded in the run summary.
+#
+#   * In a contributor's own fork, where the author tests their own branch before
+#     asking anyone to review it. Nothing special is needed to allow this: the
+#     sandbox defaults to the sandbox repo of whoever owns the repo the workflow
+#     is running in, so a fork's run acts on the fork owner's sandbox and uses
+#     the fork owner's token. A fork cannot reach the Apache sandbox through it.
+
+name: Test a change against the sandbox repo
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number in THIS repository to test. Takes precedence over 'ref'. In the Apache repo this covers PRs opened from forks; in your own fork, use 'ref' instead."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag or commit SHA to test. Ignored when 'pr' is set."
+        type: string
+        default: "main"
+      sandbox_branch:
+        description: "Branch of the sandbox repo holding the .asf.yaml under test."
+        type: string
+        default: "main"
+      sandbox_repo:
+        description: "Sandbox repo to act on, as owner/name. Defaults to <owner of this repo>/infrastructure-asfyaml-sandbox."
+        type: string
+        default: ""
+      noop:
+        description: "Dry run: report what would change without modifying the sandbox repo."
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sandbox-test:
+    runs-on: ubuntu-latest
+    # Holds ASFYAML_SANDBOX_TOKEN. Protection rules on this environment (required
+    # reviewers, branch restrictions) also apply to this job. A fork creates its
+    # own environment of the same name, holding the fork owner's own token.
+    environment: sandbox
+    steps:
+      - name: Resolve the inputs
+        id: resolve
+        env:
+          PR: ${{ inputs.pr }}
+          REF: ${{ inputs.ref }}
+          SANDBOX_BRANCH: ${{ inputs.sandbox_branch }}
+          SANDBOX_REPO: ${{ inputs.sandbox_repo }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          # Refs reach a checkout, a shell argument and $GITHUB_OUTPUT, so keep
+          # them to the characters a ref can legitimately contain. This step runs
+          # before any checkout, so a rejection stops the job here.
+          for pair in "ref:${REF}" "sandbox_branch:${SANDBOX_BRANCH}"; do
+            name="${pair%%:*}"
+            value="${pair#*:}"
+            if [[ -n "${value}" && ! "${value}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+              echo "::error::'${name}' may only contain letters, digits, '.', '_', '/' and '-'"
+              exit 1
+            fi
+          done
+          if [[ -z "${SANDBOX_BRANCH}" ]]; then
+            echo "::error::'sandbox_branch' must be set"
+            exit 1
+          fi
+
+          # The sandbox to act on. Unset means "the sandbox belonging to whoever
+          # owns the repo this workflow is running in", which is what makes a run
+          # from a fork stay inside that fork owner's own sandbox.
+          if [[ -z "${SANDBOX_REPO}" ]]; then
+            SANDBOX_REPO="${REPO_OWNER}/infrastructure-asfyaml-sandbox"
+          fi
+          if [[ ! "${SANDBOX_REPO}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::'sandbox_repo' must be of the form owner/name, got '${SANDBOX_REPO}'"
+            exit 1
+          fi
+          SANDBOX_OWNER="${SANDBOX_REPO%%/*}"
+          if [[ "${SANDBOX_OWNER}" != "${REPO_OWNER}" ]]; then
+            echo "::notice::acting on ${SANDBOX_REPO}, which is not owned by ${REPO_OWNER}. This needs a token with admin rights on it."
+          fi
+          {
+            echo "sandbox_repo=${SANDBOX_REPO}"
+            echo "sandbox_owner=${SANDBOX_OWNER}"
+            # The parser derives the GitHub repo it acts on from the directory
+            # name it is given, so the checkout directory has to be the repo name.
+            echo "sandbox_dir=${SANDBOX_REPO##*/}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ -n "${PR}" ]]; then
+            # Validate before this ends up in a ref: a PR number is digits, nothing else.
+            if [[ ! "${PR}" =~ ^[0-9]+$ ]]; then
+              echo "::error::'pr' must be a plain PR number, got '${PR}'"
+              exit 1
+            fi
+            if [[ -n "${REF}" && "${REF}" != "main" ]]; then
+              echo "::error::set either 'pr' or 'ref', not both (got pr='${PR}' ref='${REF}')"
+              exit 1
+            fi
+            echo "ref=refs/pull/${PR}/head" >> "$GITHUB_OUTPUT"
+          else
+            if [[ -z "${REF}" ]]; then
+              echo "::error::set either 'pr' or 'ref'"
+              exit 1
+            fi
+            echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out the parser under test
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.resolve.outputs.ref }}
+          path: parser
+          persist-credentials: false
+
+      - name: Check out the sandbox repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ steps.resolve.outputs.sandbox_repo }}
+          ref: ${{ inputs.sandbox_branch }}
+          path: sandbox/${{ steps.resolve.outputs.sandbox_dir }}
+          persist-credentials: false
+
+      - name: Record what is being run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr }}
+          REF: ${{ steps.resolve.outputs.ref }}
+          SANDBOX_REPO: ${{ steps.resolve.outputs.sandbox_repo }}
+          SANDBOX_DIR: ${{ steps.resolve.outputs.sandbox_dir }}
+          SANDBOX_BRANCH: ${{ inputs.sandbox_branch }}
+          NOOP: ${{ inputs.noop }}
+        run: |
+          set -euo pipefail
+          SHA="$(git -C parser rev-parse HEAD)"
+          AUTHOR="n/a"
+          if [[ -n "${PR}" ]]; then
+            AUTHOR="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .user.login || echo unknown)"
+          fi
+          {
+            echo "## Sandbox test"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Parser repo | \`${GITHUB_REPOSITORY}\` |"
+            echo "| Parser ref | \`${REF}\` |"
+            echo "| Parser commit | \`${SHA}\` |"
+            echo "| PR author | ${AUTHOR} |"
+            echo "| Sandbox repo | \`${SANDBOX_REPO}\` |"
+            echo "| Sandbox branch | \`${SANDBOX_BRANCH}\` |"
+            echo "| Dry run (noop) | ${NOOP} |"
+            echo
+            echo "Confirm that \`${SHA}\` is the commit you reviewed. A push to the"
+            echo "PR after your review changes the code this run executed."
+            echo
+            echo "### .asf.yaml under test"
+            echo
+            echo '```yaml'
+            cat "sandbox/${SANDBOX_DIR}/.asf.yaml" 2>/dev/null || echo "# no .asf.yaml on this branch"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.11"
+
+      - name: Install the parser
+        working-directory: parser
+        run: |
+          python3 -m pip install --upgrade poetry
+          poetry install
+
+      - name: Apply the .asf.yaml to the sandbox repo
+        working-directory: parser
+        env:
+          GH_TOKEN: ${{ secrets.ASFYAML_SANDBOX_TOKEN }}
+          SANDBOX_OWNER: ${{ steps.resolve.outputs.sandbox_owner }}
+          SANDBOX_DIR: ${{ steps.resolve.outputs.sandbox_dir }}
+          SANDBOX_BRANCH: ${{ inputs.sandbox_branch }}
+          NOOP: ${{ inputs.noop }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "::error::ASFYAML_SANDBOX_TOKEN is not set on the 'sandbox' environment of this repository. See docs/testing-a-change.md."
+            exit 1
+          fi
+          NOOP_FLAG="--noop"
+          if [[ "${NOOP}" == "false" ]]; then
+            NOOP_FLAG="--no-noop"
+          fi
+          poetry run asfyaml-run \
+            --repo "../sandbox/${SANDBOX_DIR}" \
+            --org "${SANDBOX_OWNER}" \
+            --branch "${SANDBOX_BRANCH}" \
+            "${NOOP_FLAG}"
+
+      - name: Link to the sandbox repo settings
+        if: always()
+        env:
+          SANDBOX_REPO: ${{ steps.resolve.outputs.sandbox_repo }}
+        run: |
+          {
+            echo
+            echo "Check the result at https://github.com/${SANDBOX_REPO}/settings and"
+            echo "reset the sandbox when you are done (see docs/testing-a-change.md)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,126 @@
+# Working in this repository
+
+Instructions for coding agents (and a useful summary for humans). This repo holds
+the parser that applies `.asf.yaml` files across the Apache Software Foundation's
+GitHub repositories, plus the documentation projects read to write those files.
+
+`CLAUDE.md` and `GEMINI.md` are symlinks to this file — one set of instructions,
+whichever name a tool looks for. Edit `AGENTS.md`; never replace a symlink with a
+copy, or the three will drift apart.
+
+## The one thing not to get wrong
+
+The parser changes real repository settings. `asfyaml-run` decides which GitHub
+repository to act on from **the name of the directory it is pointed at**, so
+`--repo /somewhere/airflow` acts on `apache/airflow`.
+
+- Never run `asfyaml-run` against a directory named after a real project.
+- Test against a sandbox repository you own, as described in
+  [docs/testing-a-change.md](docs/testing-a-change.md).
+- Prefer `--noop` (a dry run) until you have a reason not to.
+- `asfyaml-validate` only checks the schema and never contacts GitHub. When
+  validation is all you need, use it.
+
+## Getting set up
+
+```bash
+poetry install
+poetry run pytest                          # the test suite
+poetry run pre-commit run --all-files      # ruff, ruff-format, mypy, license headers
+```
+
+Python 3.10 is the floor; CI runs 3.10 through 3.13.
+
+## Layout
+
+| Path | What lives there |
+|---|---|
+| `asfyaml/asfyaml.py` | the instance and the `ASFYamlFeature` base class |
+| `asfyaml/feature/` | one module per `.asf.yaml` feature |
+| `asfyaml/feature/github/` | the `github:` feature, one module per directive group |
+| `asfyaml/cli.py` | the `asfyaml-run` and `asfyaml-validate` entry points |
+| `tests/` | pytest suite |
+| `README.md` | **the user-facing `.asf.yaml` documentation** |
+| `docs/ASFYamlFeature.md` | how to write a feature |
+| `docs/testing.md` | preview environments, for projects trying out new features |
+| `docs/testing-a-change.md` | how to test a change to the parser itself |
+
+## Conventions
+
+- **Tests are not named `test_*.py`.** `pytest` is configured with
+  `python_files = "*.py"`, so a test module is named after what it covers —
+  `tests/github_rulesets.py`, `tests/cli.py`. A file added as `test_foo.py` will
+  run, but it will not match anything else in the directory.
+- **New features must be registered.** A subclass of `ASFYamlFeature` is only
+  picked up if its module is imported in `asfyaml/feature/__init__.py`.
+- **A schema change is a documentation change.** `README.md` is what projects
+  actually read; a new or altered directive that is not described there does not
+  really exist. Update it in the same PR.
+- Python files carry the ASF license header — the `insert-license` pre-commit hook
+  adds it.
+- Line length is 120 (`ruff`). `ruff format` decides formatting; do not hand-format
+  around it.
+- `mypy` runs over `asfyaml/` only; `tests/` is excluded.
+
+## Testing a change
+
+Unit tests show that a feature parses its YAML and calls the API it meant to call.
+They do not show that GitHub accepts the call, or that the result is the one the
+contributor had in mind. For anything that touches the GitHub API, run it against
+a sandbox repository as well.
+
+**[docs/testing-a-change.md](docs/testing-a-change.md) is the full process.** In
+short, to test your own branch in your own fork:
+
+1. Enable Actions on your fork (GitHub disables them on new forks).
+2. Create `<your account>/infrastructure-asfyaml-sandbox` — a throwaway repo you
+   own, with a small baseline `.asf.yaml` on `main`.
+3. Create a `sandbox` environment in your fork, with a secret
+   `ASFYAML_SANDBOX_TOKEN`: a fine-grained token whose repository access is **only**
+   that sandbox repo.
+4. Push a branch to the sandbox carrying the `.asf.yaml` that exercises your change,
+   then run the `Test a change against the sandbox repo` workflow from your fork's
+   Actions tab with `ref` set to your branch and `noop` left on. Repeat with
+   `noop` off, check the result, and reset the sandbox afterwards.
+
+The sandbox target follows whoever owns the repo the workflow runs in, so a run
+from your fork acts on your sandbox with your token. You do not need any access to
+the Apache sandbox, and cannot reach it from your fork.
+
+Report what you saw in the pull request. A reviewer who reads "I ran this against
+my own sandbox and `required_signatures` appeared under Settings → Branches" has a
+far easier job than one starting from nothing.
+
+## Opening a pull request
+
+1. **Work on a branch in your own fork**, not on `main`.
+2. **One logical change per PR.** Unrelated cleanups belong in their own PR.
+3. **Run the checks before pushing** — `poetry run pytest` and
+   `poetry run pre-commit run --all-files`. CI runs the same ones.
+4. **Write the commit message for someone who will read it in a year.** A short
+   subject line, then prose explaining what problem the change solves and why it
+   was solved this way. What the diff does is visible in the diff; why it does it
+   is not.
+5. **In the PR description**, say what changed, what you tested and how, and
+   anything a reviewer needs that isn't in the diff — a setting that has to exist,
+   a follow-up you deliberately left out. If you tested against a sandbox, say so
+   and link the run.
+6. **Open it against `apache/infrastructure-asfyaml`, base `main`**:
+
+   ```bash
+   gh pr create --repo apache/infrastructure-asfyaml --base main \
+     --head <your account>:<your branch> \
+     --title "..." --body-file <file>
+   ```
+
+7. Report issues and suggestions as **GitHub issues in this repository**. Do not
+   open Jira tickets for this repo.
+
+### If you are an agent
+
+- Do not commit, push, or open a pull request unless you were asked to. Say what
+  you would do and let the human decide.
+- Show the human the commit message and the PR description before they are used.
+  Both are published under their name.
+- Do not claim a change was tested unless you ran something and read the output.
+  "The tests pass" means you ran them in this session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > This is a work in progress. There will be omissions, factually incorrect items,
 > and placeholders while we work to fully migrate the .asf.yaml specifications to this repository.
 > Issues can be reported in this repository, and Pull Requests are also welcome.
+> Changing the parser itself? See [how to test a change against the sandbox repo](docs/testing-a-change.md).
 > We ask that you do not create Jira tickets for suggestions or other remarks concerning this repository.
 
 # Working with .asf.yaml

--- a/asfyaml/cli.py
+++ b/asfyaml/cli.py
@@ -30,13 +30,35 @@ def dir_path(path):
         raise argparse.ArgumentTypeError(f"readable_dir:{path} is not a valid path")
 
 
-def cli():
+def branch_ref(branch):
+    """Normalises a branch argument into a full ``refs/heads/`` ref."""
+    branch = branch.strip()
+    if not branch:
+        raise argparse.ArgumentTypeError("branch must not be empty")
+    if branch.startswith("refs/heads/"):
+        return branch
+    if branch.startswith("refs/"):
+        raise argparse.ArgumentTypeError(f"'{branch}' is not a branch, .asf.yaml is only processed on branches")
+    return f"refs/heads/{branch}"
+
+
+def run_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", type=dir_path, help="path to the repo to process", required=True)
     parser.add_argument("--org", type=str, default="apache", help="the organization this repo belongs to")
     parser.add_argument("--token", type=str, help="token to access the repo via the GH API")
     parser.add_argument("--noop", action=argparse.BooleanOptionalAction, default=False, help="do not perform changes")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--branch",
+        type=branch_ref,
+        default=dataobjects.DEFAULT_BRANCH,
+        help="the branch the .asf.yaml is being processed for, e.g. 'main' or 'refs/heads/main'",
+    )
+    return parser
+
+
+def cli():
+    args = run_parser().parse_args()
 
     repo_path = Path(os.path.abspath(args.repo))
     repo = dataobjects.Repository(str(repo_path), org_id=args.org)
@@ -59,7 +81,7 @@ def cli():
             "no GitHub token has been provided, either add a '--token' argument or set a 'GH_TOKEN' env variable."
         )
 
-    a = ASFYamlInstance(repo, "anonymous", yml_content, dataobjects.DEFAULT_BRANCH)
+    a = ASFYamlInstance(repo, "anonymous", yml_content, args.branch)
 
     if args.noop:
         a.environments_enabled.add("noop")
@@ -69,12 +91,22 @@ def cli():
     a.run_parts()
 
 
-def validate():
-    """Validates a .asf.yaml file according to the current schema."""
+def validate_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", type=dir_path, help="path to the repo to process", required=True)
     parser.add_argument("--org", type=str, default="apache", help="the organization this repo belongs to")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--branch",
+        type=branch_ref,
+        default=dataobjects.DEFAULT_BRANCH,
+        help="the branch the .asf.yaml is being processed for, e.g. 'main' or 'refs/heads/main'",
+    )
+    return parser
+
+
+def validate():
+    """Validates a .asf.yaml file according to the current schema."""
+    args = validate_parser().parse_args()
 
     repo_path = Path(os.path.abspath(args.repo))
     repo = dataobjects.Repository(str(repo_path), org_id=args.org)
@@ -89,7 +121,7 @@ def validate():
     os.environ["PATH_INFO"] = repo_path.name
     os.environ["GIT_PROJECT_ROOT"] = str(repo_path.parent)
 
-    a = ASFYamlInstance(repo, "anonymous", yml_content, dataobjects.DEFAULT_BRANCH)
+    a = ASFYamlInstance(repo, "anonymous", yml_content, args.branch)
 
     a.environments_enabled.add("production")
 

--- a/docs/testing-a-change.md
+++ b/docs/testing-a-change.md
@@ -1,0 +1,275 @@
+# Testing a parser change against the sandbox repo
+
+This page is for people **changing or reviewing the `.asf.yaml` parser itself**.
+If you are a project looking to try out a preview feature in your own repository,
+see [testing.md](testing.md) instead.
+
+Unit tests prove that a feature parses its YAML and calls the API it means to
+call. They do not prove that GitHub accepts the call, or that the result is the
+one the contributor had in mind. For that, the parser has to run against a real
+repository — which is what
+[`apache/infrastructure-asfyaml-sandbox`](https://github.com/apache/infrastructure-asfyaml-sandbox)
+is for. It is a throwaway repo: its settings, branch protections, labels and
+rulesets exist to be mangled and reset.
+
+The `Test a change against the sandbox repo` workflow
+([`.github/workflows/sandbox-test.yaml`](../.github/workflows/sandbox-test.yaml))
+takes any version of the parser — including a pull request opened from a fork —
+and applies a `.asf.yaml` of your choosing to a sandbox repo.
+
+## Two places this runs
+
+| | In `apache/infrastructure-asfyaml` | In your own fork |
+|---|---|---|
+| Who dispatches it | a committer, reviewing a PR | you, the author, before asking for review |
+| Which sandbox | `apache/infrastructure-asfyaml-sandbox` | `<your account>/infrastructure-asfyaml-sandbox` |
+| Whose token | the one infra put on the Apache repo | one you make yourself |
+| Which ref | the `pr` input, PR number in the Apache repo | the `ref` input, a branch on your fork |
+| Setup needed | none, it's already there | [a few minutes, once](#setting-it-up-in-your-own-fork) |
+
+The sandbox target is not hardcoded: it defaults to the sandbox repo of **whoever
+owns the repository the workflow is running in**. So the same workflow file, run
+from your fork, acts on your sandbox with your token, and a fork cannot reach the
+Apache sandbox through it. Everything below applies to both; the differences are
+called out where they matter.
+
+Testing in your own fork first is the polite thing to do — it turns "does this
+work?" into "here is what it did", and it spends your GitHub minutes and your
+sandbox instead of the project's.
+
+## Before you press the button
+
+> [!WARNING]
+> Dispatching this workflow **executes code from the ref you name**, with a token
+> that has admin rights on the sandbox repo. For a PR from a fork, that is code
+> written by someone outside the project. GitHub restricts `workflow_dispatch` to
+> people with write access, and **that person is the security control**: read the
+> diff before you run it, and check that the commit SHA recorded in the run
+> summary is the one you read. A push to the PR between your review and your
+> dispatch changes the code that runs.
+
+Nothing outside the sandbox repo is in the token's reach, but the token is in the
+reach of whatever the PR's code does with it. Treat "I ran the sandbox test" as a
+statement about a specific commit, not about a PR.
+
+None of this applies to a run in your own fork: the code, the sandbox and the
+token are all yours, and there is nobody else's trust to spend. That is the
+other reason to self-test first.
+
+## Testing a change, step by step
+
+### 1. Read the diff
+
+Look at the PR as you normally would, and note the head SHA (`Commits` tab, or
+`gh pr view <NNN> --json headRefOid`). You will confirm it in step 3.
+
+Self-testing your own branch in your own fork? There is nothing to vouch for —
+start at step 2.
+
+### 2. Put the `.asf.yaml` under test on a sandbox branch
+
+The parser reads its configuration from a branch of the sandbox repo, so write
+the configuration that exercises the change and push it there. Use the Apache
+sandbox if you are a committer reviewing a PR, or your own if you are the author
+self-testing:
+
+```bash
+git clone https://github.com/apache/infrastructure-asfyaml-sandbox.git   # or <your account>/...
+cd infrastructure-asfyaml-sandbox
+git switch -c test/pr-42          # convention: test/pr-<PR number>
+$EDITOR .asf.yaml                 # the configuration you want to try
+git commit -am "Test config for PR #42"
+git push origin test/pr-42
+```
+
+Keep the configuration minimal — just the feature under test, plus whatever it
+depends on. A large `.asf.yaml` makes it harder to attribute a surprising result
+to the change.
+
+### 3. Dry run
+
+Go to
+[Actions → Test a change against the sandbox repo](../../actions/workflows/sandbox-test.yaml)
+→ `Run workflow` and fill in:
+
+| Field | Value |
+|---|---|
+| Use workflow from | **`main`** — see [Why the dropdown stays on main](#why-the-dropdown-stays-on-main) |
+| `pr` | the PR number, e.g. `42`. **In your fork, leave this empty** — see below |
+| `ref` | leave as `main` when using `pr`; **in your fork, your branch name** |
+| `sandbox_branch` | `test/pr-42` |
+| `sandbox_repo` | leave empty — it defaults to your own sandbox |
+| `noop` | **`true`** |
+
+`pr` means "a PR in the repository this workflow is running in". In
+`apache/infrastructure-asfyaml` that is the PR under review, and it resolves to
+`refs/pull/<n>/head`, a ref that exists on the Apache repo even when the PR came
+from a fork — which is why a fork PR needs no mirror branch. In your own fork
+there are normally no PRs, so name your branch in `ref` instead.
+
+The run summary records the ref, the **commit SHA**, the PR author, the sandbox
+branch, and the `.asf.yaml` that was read. **Check the SHA against step 1.**
+
+With `noop` on, the parser reads from the GitHub API and reports what each
+feature would do without changing anything. Most mistakes — a bad schema, a
+malformed API payload, a feature that never fires — show up here.
+
+### 4. Apply it for real
+
+Dispatch again with the same inputs and `noop` set to `false`.
+
+### 5. Verify on the sandbox repo
+
+Check the thing the change was supposed to affect:
+
+| Feature | Where to look |
+|---|---|
+| `description`, `homepage`, `labels`, `features` | the sandbox repo's front page and `Settings` |
+| `protected_branches`, `protected_tags` | `Settings → Branches`, `Settings → Tags` |
+| `rulesets` | `Settings → Rules` |
+| `del_branch_on_merge`, `enabled_merge_buttons`, `pull_requests` | `Settings → General` |
+| `dependabot_alerts`, `dependabot_updates` | `Settings → Advanced Security` |
+| `environments` | `Settings → Environments` |
+| `copilot_code_review` | `Settings → Rules`, and a PR in the sandbox |
+| `ghp_branch`, `ghp_path` | `Settings → Pages` |
+| `collaborators` | `Settings → Collaborators` (invitations are pending until accepted) |
+| `autolink_jira` | `Settings → Autolink references` |
+
+### 6. Reset the sandbox
+
+Leaving the sandbox in a mangled state makes the *next* reviewer's result
+ambiguous, so put it back:
+
+1. Dispatch the workflow once more with `ref` = `main`, `pr` empty,
+   `sandbox_branch` = `main`, `noop` = `false`. This re-applies the baseline
+   `.asf.yaml` from the sandbox's main branch. (Resetting your own sandbox
+   matters less than resetting the shared one, but stale settings will confuse
+   your next run too.)
+2. Delete your test branch: `git push origin --delete test/pr-42`.
+3. Anything the baseline cannot undo — a created ruleset, a pending collaborator
+   invitation, an environment — remove by hand.
+
+### 7. Say so in the PR
+
+Post what you ran, so the next person does not repeat it:
+
+> Sandbox-tested at `abc1234` against `test/pr-42` — `protected_branches` applied
+> as expected, `required_signatures` showed up in Settings → Branches.
+> Run: <link to the workflow run>
+
+## Setting it up in your own fork
+
+Four things, once, and then every later branch is just a dispatch:
+
+1. **Enable Actions on your fork.** GitHub disables workflows on new forks. Open
+   the fork's `Actions` tab and confirm the prompt; the workflow then shows up
+   with its `Run workflow` button.
+2. **Make yourself a sandbox repo.** Create
+   `<your account>/infrastructure-asfyaml-sandbox` — the default name, so you
+   never have to fill in `sandbox_repo`. Any repo you own with admin rights will
+   do; pass its `owner/name` in `sandbox_repo` if you call it something else.
+   Give it a small baseline `.asf.yaml` on `main` so you have something to reset
+   to. Keep it public, or the checkout step cannot read it.
+3. **Create a `sandbox` environment** in your fork
+   (`Settings → Environments → New environment`, named exactly `sandbox`).
+4. **Add an `ASFYAML_SANDBOX_TOKEN` secret to that environment**: a fine-grained
+   personal access token whose repository access is **only** your sandbox repo,
+   with `Administration: read and write` (plus `Contents`, `Pages` or
+   `Environments` if you are testing those features). Scope it to that one repo —
+   a token with `Administration` on all your repositories is a bad thing to hand
+   to a CI job.
+
+Then follow the same steps as above, with `ref` set to your branch instead of
+`pr`, and push your test `.asf.yaml` to a branch of *your* sandbox. When you open
+the PR, say what you saw — a reviewer who can read "I ran this against my own
+sandbox and `required_signatures` appeared in Settings → Branches" has a much
+easier job than one starting from scratch.
+
+> [!TIP]
+> A run in your fork is not a substitute for the reviewer's run against the
+> Apache sandbox — your token, your sandbox settings and your repo's existing
+> state all differ. It is there to catch the obvious breakage before anyone else
+> spends time on it.
+
+## Testing locally instead
+
+The workflow is a wrapper around one command, and you can run it yourself with a
+token of your own:
+
+```bash
+git clone https://github.com/apache/infrastructure-asfyaml-sandbox.git
+cd infrastructure-asfyaml-sandbox && git switch test/pr-42 && cd ..
+
+git clone https://github.com/apache/infrastructure-asfyaml.git parser
+cd parser && gh pr checkout 42 && poetry install
+
+poetry run asfyaml-run \
+  --repo ../infrastructure-asfyaml-sandbox \
+  --org apache \
+  --branch test/pr-42 \
+  --noop \
+  --token "$GH_TOKEN"
+```
+
+Drop `--noop` (or pass `--no-noop`) to apply the changes. `--org` is the owner of
+the sandbox you are acting on, so it is your own account when you run this against
+your own sandbox.
+
+> [!IMPORTANT]
+> **The checkout directory name is the GitHub repo name.** The parser derives the
+> repository it acts on from the directory it is given, so
+> `--repo /somewhere/infrastructure-asfyaml-sandbox` acts on
+> `apache/infrastructure-asfyaml-sandbox`. Renaming the directory points the run
+> at a different repo — including, if you get it wrong, a real project's.
+
+To check only that a configuration is valid, without contacting GitHub at all:
+
+```bash
+poetry run asfyaml-validate --repo ../infrastructure-asfyaml-sandbox --branch test/pr-42
+```
+
+## Things that surprise people
+
+### Why the dropdown stays on main
+
+`workflow_dispatch` runs the *workflow definition* from the branch chosen in the
+`Use workflow from` dropdown. Leaving it on `main` means the steps that handle
+the token come from reviewed code, while the parser under test is checked out as
+data. Selecting a PR branch there would let that PR rewrite the runner itself.
+
+### Branch-scoped and repo-scoped settings behave differently
+
+`sandbox_branch` decides which branch's `.asf.yaml` is *read*, and which branch
+the parser believes it is processing. Features keyed on the branch — website
+staging and publishing, `whoami`, Pelican and Jekyll builds — only fire when the
+branch matches. Repository metadata under `github:` is not branch-scoped: it
+applies to the whole repo no matter which branch it was read from. So a
+`description:` change takes effect even when read from `test/pr-42`, while a
+`publish:` block may do nothing at all.
+
+### `noop` is not offline
+
+A dry run still authenticates and reads from the GitHub API — that is how it can
+report what *would* change. It only suppresses the writes.
+
+## One-time setup for the Apache repo (infra)
+
+The workflow needs these to exist in `apache/infrastructure-asfyaml`. They are
+outside this repository:
+
+1. **The sandbox repo**, `apache/infrastructure-asfyaml-sandbox`, public, with a
+   baseline `.asf.yaml` on `main` that represents "settings at rest". Keep the
+   baseline small and boring; step 6 above resets to it.
+2. **A `sandbox` environment** on `apache/infrastructure-asfyaml`
+   (`Settings → Environments`). Required reviewers can be added here if
+   committer-only dispatch is judged too weak a gate.
+3. **A secret `ASFYAML_SANDBOX_TOKEN`** on that environment: a fine-grained
+   personal access token, or a GitHub App installation token, whose repository
+   access is **only** `apache/infrastructure-asfyaml-sandbox`. Grant the
+   permissions the features under test need — `Administration: read and write`
+   covers most repository settings, with `Contents`, `Pages` and `Environments`
+   for the features that use them. Do not use a token with access to other
+   repositories in the org.
+
+The workflow fails with a clear message when the secret is missing, so a
+half-finished setup is not silently a no-op.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,10 @@
 # Testing new features
 
+> [!NOTE]
+> This page is about trying out preview features **in your own project's repository**.
+> If you are changing or reviewing the `.asf.yaml` parser itself, see
+> [Testing a parser change against the sandbox repo](testing-a-change.md).
+
 Any git repository within the ASF ecosystem can be used for testing new or upcoming features.
 Enabling a feature branch can be done via the `meta` feature:
 

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the command line entry points."""
+
+import argparse
+
+import pytest
+
+from asfyaml import cli
+
+
+def test_plain_branch_name_becomes_a_full_ref():
+    assert cli.branch_ref("main") == "refs/heads/main"
+
+
+def test_branch_name_with_slashes_becomes_a_full_ref():
+    assert cli.branch_ref("test/pr-42-rulesets") == "refs/heads/test/pr-42-rulesets"
+
+
+def test_full_branch_ref_is_passed_through_unchanged():
+    assert cli.branch_ref("refs/heads/main") == "refs/heads/main"
+
+
+def test_tag_ref_is_rejected():
+    with pytest.raises(argparse.ArgumentTypeError, match="not a branch"):
+        cli.branch_ref("refs/tags/v1.0.0")
+
+
+def test_empty_branch_is_rejected():
+    with pytest.raises(argparse.ArgumentTypeError, match="must not be empty"):
+        cli.branch_ref("")
+
+
+def test_run_parser_defaults_to_the_main_branch():
+    args = cli.run_parser().parse_args(["--repo", "."])
+    assert args.branch == "refs/heads/main"
+
+
+def test_run_parser_normalises_the_branch_argument():
+    args = cli.run_parser().parse_args(["--repo", ".", "--branch", "test/pr-42"])
+    assert args.branch == "refs/heads/test/pr-42"
+
+
+def test_validate_parser_normalises_the_branch_argument():
+    args = cli.validate_parser().parse_args(["--repo", ".", "--branch", "refs/heads/staging"])
+    assert args.branch == "refs/heads/staging"

--- a/tests/sandbox_workflow.py
+++ b/tests/sandbox_workflow.py
@@ -1,0 +1,161 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the input resolution in the sandbox test workflow.
+
+The workflow hands what this step resolves to `actions/checkout` and to shell
+arguments, so the validation here is what keeps a dispatch from turning into
+arbitrary code or ref injection. It also decides which repository the run is
+allowed to modify, which is what keeps a fork's run inside the fork's own
+sandbox. These tests run the step's script the way the runner would.
+"""
+
+import subprocess
+
+import pytest
+import yaml
+
+WORKFLOW = "../.github/workflows/sandbox-test.yaml"
+
+
+def resolve_script(base_path):
+    """Extracts the 'run' script of the workflow's input resolution step."""
+    workflow = yaml.safe_load(base_path.joinpath(WORKFLOW).read_text())
+    steps = workflow["jobs"]["sandbox-test"]["steps"]
+    step = next(s for s in steps if s.get("id") == "resolve")
+    return step["run"]
+
+
+def run_resolve(
+    base_path,
+    tmp_path,
+    pr="",
+    ref="main",
+    sandbox_branch="main",
+    sandbox_repo="",
+    owner="apache",
+):
+    """Runs the resolution script, returning (exit code, resolved outputs)."""
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+    result = subprocess.run(
+        ["bash", "-c", resolve_script(base_path)],
+        env={
+            "PATH": "/usr/bin:/bin",
+            "PR": pr,
+            "REF": ref,
+            "SANDBOX_BRANCH": sandbox_branch,
+            "SANDBOX_REPO": sandbox_repo,
+            "REPO_OWNER": owner,
+            "GITHUB_OUTPUT": str(output_file),
+        },
+        capture_output=True,
+        text=True,
+    )
+    outputs = {}
+    for line in output_file.read_text().splitlines():
+        key, _, value = line.partition("=")
+        outputs[key] = value
+    return result.returncode, outputs
+
+
+def test_pr_number_resolves_to_the_pull_request_head(base_path, tmp_path):
+    code, outputs = run_resolve(base_path, tmp_path, pr="42")
+    assert (code, outputs["ref"]) == (0, "refs/pull/42/head")
+
+
+def test_ref_is_used_when_no_pr_is_given(base_path, tmp_path):
+    code, outputs = run_resolve(base_path, tmp_path, ref="feat/my-branch")
+    assert (code, outputs["ref"]) == (0, "feat/my-branch")
+
+
+def test_sandbox_branch_may_contain_slashes(base_path, tmp_path):
+    assert run_resolve(base_path, tmp_path, pr="42", sandbox_branch="test/pr-42")[0] == 0
+
+
+@pytest.mark.parametrize(
+    "pr",
+    ["abc", "42; whoami", "42/head", "-1", "4 2", "$(whoami)"],
+)
+def test_a_pr_that_is_not_a_plain_number_is_rejected(base_path, tmp_path, pr):
+    assert run_resolve(base_path, tmp_path, pr=pr)[0] != 0
+
+
+@pytest.mark.parametrize(
+    "ref",
+    ["main; whoami", "$(whoami)", "main\nref=refs/pull/1/head", "main branch", "`whoami`"],
+)
+def test_a_ref_with_shell_or_newline_characters_is_rejected(base_path, tmp_path, ref):
+    assert run_resolve(base_path, tmp_path, ref=ref)[0] != 0
+
+
+@pytest.mark.parametrize(
+    "sandbox_branch",
+    ["main; whoami", "$(whoami)", "main\nref=refs/pull/1/head", ""],
+)
+def test_an_invalid_sandbox_branch_is_rejected(base_path, tmp_path, sandbox_branch):
+    assert run_resolve(base_path, tmp_path, pr="42", sandbox_branch=sandbox_branch)[0] != 0
+
+
+def test_setting_both_pr_and_a_non_default_ref_is_rejected(base_path, tmp_path):
+    assert run_resolve(base_path, tmp_path, pr="42", ref="some-branch")[0] != 0
+
+
+# The sandbox target follows the repo the workflow runs in, so that a fork's run
+# acts on the fork owner's sandbox rather than on the Apache one.
+
+
+def test_sandbox_defaults_to_the_sandbox_of_the_owner_running_the_workflow(base_path, tmp_path):
+    code, outputs = run_resolve(base_path, tmp_path, owner="apache")
+    assert code == 0
+    assert outputs["sandbox_repo"] == "apache/infrastructure-asfyaml-sandbox"
+    assert outputs["sandbox_owner"] == "apache"
+    assert outputs["sandbox_dir"] == "infrastructure-asfyaml-sandbox"
+
+
+def test_a_fork_defaults_to_the_fork_owners_sandbox(base_path, tmp_path):
+    code, outputs = run_resolve(base_path, tmp_path, owner="somecontributor")
+    assert code == 0
+    assert outputs["sandbox_repo"] == "somecontributor/infrastructure-asfyaml-sandbox"
+    assert outputs["sandbox_owner"] == "somecontributor"
+
+
+def test_an_explicit_sandbox_repo_overrides_the_default(base_path, tmp_path):
+    code, outputs = run_resolve(
+        base_path, tmp_path, owner="somecontributor", sandbox_repo="somecontributor/my-test-repo"
+    )
+    assert code == 0
+    assert outputs["sandbox_repo"] == "somecontributor/my-test-repo"
+    assert outputs["sandbox_owner"] == "somecontributor"
+    assert outputs["sandbox_dir"] == "my-test-repo"
+
+
+@pytest.mark.parametrize(
+    "sandbox_repo",
+    [
+        "noslash",
+        "too/many/slashes",
+        "owner name/repo",
+        "$(whoami)/repo",
+        "owner/repo; whoami",
+        "owner/repo\nref=refs/pull/1/head",
+        "/repo",
+        "owner/",
+    ],
+)
+def test_a_malformed_sandbox_repo_is_rejected(base_path, tmp_path, sandbox_repo):
+    assert run_resolve(base_path, tmp_path, sandbox_repo=sandbox_repo)[0] != 0


### PR DESCRIPTION
## Why

Our unit tests show that a feature parses its YAML and calls the API it means to
call. They don't show that GitHub accepts the call, or that the result is the one
the contributor had in mind. Today a reviewer who wants to know that has to point
the CLI at some repository by hand, an author has no way to check at all before
asking for review, and there's no shared account of how any of it is done.

## What this adds

**A `workflow_dispatch` workflow** (`Test a change against the sandbox repo`) that
applies a given version of the parser to a sandbox repo. Inputs: `pr` (or `ref`),
`sandbox_branch`, `sandbox_repo`, and `noop` (defaulting to a dry run).

It runs in two places, with no fork-specific code path:

- **In this repo**, a committer tests a PR before merging. A PR number resolves to
  `refs/pull/<n>/head` — a ref on the base repo — so **PRs opened from forks can be
  tested without pushing a mirror branch anywhere.**
- **In a contributor's own fork**, the author tests their own branch before asking
  anyone to look. The sandbox defaults to the sandbox repo of whoever owns the
  repository the workflow is running in, so a fork's run acts on the fork owner's
  sandbox with the fork owner's token — and **cannot reach the Apache sandbox
  through it.** The contributor needs four things once (Actions enabled on the
  fork, their own sandbox repo, a `sandbox` environment, a token scoped to that
  repo); the docs walk through it.

The run summary records the resolved ref, the commit SHA, the PR author, and the
`.asf.yaml` that was read, so a reviewer can confirm the run executed the commit
they actually read.

**`--branch` on `asfyaml-run` and `asfyaml-validate`.** Both hardcoded
`refs/heads/main`, so nothing branch-sensitive (`whoami`, website staging and
publishing, `ghp_branch`) could be exercised, and the workflow needs to name the
sandbox branch carrying the config under test. `main` and `refs/heads/main` are
both accepted; tag refs are rejected.

**`docs/testing-a-change.md`** — both paths end to end: read the diff → push a
`test/pr-NNN` branch to the sandbox → dry run → apply → verify (with a
per-directive table of where to look in Settings) → **reset the sandbox** → report
the result on the PR. Plus the fork setup, the local-CLI equivalent, and the things
that catch people out: why the workflow dropdown stays on `main`, why `github:`
metadata applies regardless of which branch it was read from while `publish:`
doesn't, and that `noop` still reads from the API.

**`AGENTS.md`, with `CLAUDE.md` and `GEMINI.md` as symlinks to it.** The repo had no
contributor-facing instructions at all, so things that are only discoverable by
reading configuration — that tests are *not* named `test_*.py` (`python_files =
"*.py"`), that a feature is invisible unless it's imported in
`asfyaml/feature/__init__.py`, that a schema change isn't real until `README.md`
describes it — had to be rediscovered each time. It leads with the mistake that
costs most: `asfyaml-run` derives the repository it acts on from the *directory
name* it is given, so a run pointed at a directory called `airflow` reconfigures
`apache/airflow`. Then setup, conventions, how to test in your own fork (pointing
here for the full process), and how to open a PR. Symlinks rather than copies so
the three files cannot drift apart.

## Security model — worth a careful look

Dispatching in this repo **executes code from the named ref with a token that has
admin rights on the Apache sandbox**, and for a fork PR that's code from outside
the project. `workflow_dispatch` limits triggering to people with write access, and
that person is the control: read the diff, then check the SHA in the run summary
matches what you read. (A run in one's own fork spends nobody else's trust, which
is the other argument for self-testing first.)

Hardening in the workflow itself: every input goes through `env:` rather than being
interpolated into `run:`; a PR number is validated as `^[0-9]+$` before it reaches a
ref; refs are held to characters a ref can legitimately contain; a sandbox repo must
be a well-formed `owner/name`; the workflow definition always comes from `main`, so
a PR can't rewrite the runner.

`tests/sandbox_workflow.py` extracts that step's script from the YAML and runs it
under bash with hostile inputs (`42; whoami`, `$(whoami)`, `owner/repo; whoami`,
embedded newlines that would inject a second `$GITHUB_OUTPUT` line). Each guard was
deleted in turn to confirm the tests fail without it.

If committer-only dispatch is judged too weak, adding required reviewers to the
`sandbox` environment tightens it with no change to this workflow.

## Needs infra before it can run here

The workflow fails with an explicit error rather than silently no-opping if these
are missing. Contributors testing in their own forks need none of it — they set up
their own equivalents.

1. `apache/infrastructure-asfyaml-sandbox`, public, with a baseline `.asf.yaml` on
   `main` — the reset step re-applies it.
2. A `sandbox` environment on this repo.
3. `ASFYAML_SANDBOX_TOKEN` on that environment: a fine-grained PAT whose repository
   access is **only** the sandbox repo. A `GITHUB_TOKEN` can't change repository
   settings, so a PAT is unavoidable here.

## Testing

38 new tests, all passing (136 total). The CLI tests were written first and watched
to fail. The workflow tests were written against an existing YAML, so each guard was
removed in turn to confirm the tests catch its absence.

`AGENTS.md` adds no tests; its factual claims were checked against `pyproject.toml`,
`.pre-commit-config.yaml` and `asfyaml/feature/__init__.py` rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yUbPm1PL7tsKZJhXFsfj7
