### PR TITLE
Group Dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Every update is grouped, so a run opens one pull request per ecosystem
+# instead of one per dependency -- three a week at most, rather than the dozen
+# or so the same set of bumps would otherwise produce.
+#
+# Dependabot can also consolidate across ecosystems into a single pull request
+# (the top-level `multi-ecosystem-groups` key). That is deliberately not used
+# here: it is a newer feature, and a configuration this file gets wrong fails
+# silently -- Dependabot rejects the file and stops updating anything, which is
+# only visible under Insights -> Dependency graph -> Dependabot. Per-ecosystem
+# grouping relies on long-established configuration and gets most of the win.
+
+version: 2
+
+# `pre-commit` is a recent addition to Dependabot's ecosystems. This flag is
+# what keeps it from being skipped if it is still gated as beta; it has no
+# effect on the other two, which are long since generally available.
+enable-beta-ecosystems: true
+
+updates:
+  # Python dependencies. Dependabot reads pyproject.toml and poetry.lock under
+  # the "pip" ecosystem; there is no separate "poetry" value.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # pyproject.toml constrains most dependencies loosely ("*", "^2.7.0") on
+    # purpose. Updating the lock file alone keeps the resolved versions current
+    # without rewriting those constraints on every bump.
+    versioning-strategy: "lockfile-only"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+      # Security fixes are grouped as well, so a batch of advisories arrives as
+      # one pull request instead of one per advisory.
+      python-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  # GitHub Actions. Every `uses:` in this repository is pinned to a commit SHA
+  # with the version in a trailing comment; Dependabot updates both, so the
+  # pinning survives the bump.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  # pre-commit hooks, whose revisions are pinned in .pre-commit-config.yaml.
+  # The local hooks in that file (ruff, mypy) come from the Python environment
+  # and are covered by the pip entry above, not here.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"
+      pre-commit-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

The repository has no Dependabot configuration, so nothing is watching
`poetry.lock`, the SHA-pinned actions in the workflows, or the pinned hook
revisions in `.pre-commit-config.yaml`. The pre-commit pins in particular
(`pre-commit-hooks v5.0.0`, `Lucas-C/pre-commit-hooks v1.5.5`) go stale quietly.

The reason to configure this rather than just enable it is volume: ungrouped,
the same set of bumps opens a dozen or so separate PRs.

## What this does

Every update is grouped, so a run opens **one PR per ecosystem** — three a week
at most:

| Ecosystem | Watches |
|---|---|
| `pip` | `pyproject.toml` + `poetry.lock` (Dependabot reads poetry under `pip`) |
| `github-actions` | every `uses:` in `.github/workflows/` |
| `pre-commit` | the pinned `rev:` of each external hook repo |

Security advisories are grouped the same way (a second group per ecosystem with
`applies-to: security-updates`), so a batch of them arrives as one PR rather
than one apiece.

**Python uses `versioning-strategy: lockfile-only`.** `pyproject.toml`
constrains most dependencies loosely (`requests = "*"`, `PyGithub = "^2.7.0"`)
on purpose; rewriting those constraints on every bump is churn against a file
that is deliberately permissive. The lock file is what needs to stay current.

**The SHA pinning survives.** All four `uses:` are pinned to a commit SHA with a
`# v4.2.2`-style trailing comment. Dependabot updates both the SHA and the
comment, so the pinning is preserved rather than undone.

**No `ignore` rules for majors.** CI here is fast; a breaking major should
surface as a red PR rather than be silently skipped.

## One deliberate omission

Dependabot can now consolidate *across* ecosystems into a single PR, via the
top-level `multi-ecosystem-groups` key. This config does not use it. It is a
newer feature, and the failure mode is bad: a config file Dependabot rejects
stops **all** updates and reports it only under Insights → Dependency graph →
Dependabot. Per-ecosystem grouping rests on long-established configuration and
collapses ~12 PRs to 3, which is most of the benefit. Easy to revisit later.

`enable-beta-ecosystems: true` is set for one reason: `pre-commit` is a recent
addition, and the flag keeps it from being skipped if it is still beta-gated. It
has no effect on the other two.

## Testing

Validated against the published Dependabot 2.0 JSON schema
(`json.schemastore.org/dependabot-2.0.json`) with `jsonschema` — full document
validation, not a spot check. `versioning-strategy: lockfile-only`,
`applies-to: security-updates`, and the `pip` / `github-actions` / `pre-commit`
ecosystem names were each confirmed present in the schema's enums rather than
assumed. Config-only change; the test suite is untouched.

Worth a maintainer checking the Dependabot tab after merge to confirm the file
is accepted and the first three PRs appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yUbPm1PL7tsKZJhXFsfj7
